### PR TITLE
Add automated Release docker builds

### DIFF
--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -1,0 +1,64 @@
+name: Build and Push Docker Image on Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write # Ensure this permission is set
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lowercase repository name
+        id: lowercase
+        run: echo "repo_lower=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract version components and generate tags
+        id: semver_tags
+        run: |
+          ref_name="${{ github.ref_name }}"
+          version="${ref_name#v}"
+          major=$(echo "$version" | cut -d. -f1)
+          major_minor=$(echo "$version" | cut -d. -f1,2)
+          image_base="ghcr.io/${{ steps.lowercase.outputs.repo_lower }}"
+          tags=$(cat <<EOF
+          ${image_base}:${major}
+          ${image_base}:${major_minor}
+          ${image_base}:${version}
+          EOF
+          )
+          echo "tags<<EOF" >> $GITHUB_OUTPUT
+          echo "$tags" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "Generated tags:" # Optional: Log the tags for debugging
+          echo "$tags"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/ArgonFetch.API/Dockerfile
+          push: true
+          cache-from: type=gha
+          cache-to: type=inline
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.semver_tags.outputs.tags }}


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Automatically builds a docker image when a release gets created.
The image tag gets parsed out of the release tag, which should follow the SemVer notation with a v as prefix (x1.0.1)

## Testing
The pipeline seams to work (tested on my Fork) but there are some build errors

## Impact
Automated builds, so less work for you.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
