### PR TITLE
fix: report the real version in deployed builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,27 @@
+<Project>
+
+  <!--
+    Single source of truth for the product version: application.properties at the
+    repository root. Stamping it here means every assembly carries the same version,
+    so runtime version lookups don't depend on which assembly they happen to run from.
+  -->
+  <PropertyGroup>
+    <ApplicationPropertiesFile>$(MSBuildThisFileDirectory)application.properties</ApplicationPropertiesFile>
+  </PropertyGroup>
+
+  <Target Name="ReadVersionFromProperties"
+          BeforeTargets="GetAssemblyVersion;GenerateAssemblyInfo"
+          Condition="Exists('$(ApplicationPropertiesFile)')">
+    <XmlPeek XmlInputPath="$(ApplicationPropertiesFile)" Query="/properties/version/text()">
+      <Output TaskParameter="Result" PropertyName="VersionFromProperties" />
+    </XmlPeek>
+    <PropertyGroup Condition="'$(VersionFromProperties)' != ''">
+      <Version>$(VersionFromProperties)</Version>
+      <VersionPrefix>$(VersionFromProperties)</VersionPrefix>
+      <AssemblyVersion>$(VersionFromProperties)</AssemblyVersion>
+      <FileVersion>$(VersionFromProperties)</FileVersion>
+      <InformationalVersion>$(VersionFromProperties)</InformationalVersion>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/src/ArgonFetch.API/ArgonFetch.API.csproj
+++ b/src/ArgonFetch.API/ArgonFetch.API.csproj
@@ -7,15 +7,7 @@
     <UserSecretsId>afdb85db-2341-41df-8afb-b35f66ffcc1a</UserSecretsId>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <ApplicationPropertiesFile>$(MSBuildProjectDirectory)\..\..\application.properties</ApplicationPropertiesFile>
-  </PropertyGroup>
-
-  <Target Name="ReadVersionFromProperties" BeforeTargets="BeforeBuild">
-    <XmlPeek XmlInputPath="$(ApplicationPropertiesFile)" Query="/properties/version/text()">
-      <Output TaskParameter="Result" PropertyName="Version" />
-    </XmlPeek>
-  </Target>
+  <!-- Version is stamped for every project by Directory.Build.props at the repository root. -->
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.11.0" />

--- a/src/ArgonFetch.Infrastructure/Services/ApplicationInfoService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/ApplicationInfoService.cs
@@ -1,15 +1,18 @@
 using ArgonFetch.Application.Services;
+using System.Reflection;
 using System.Xml.Linq;
 
 namespace ArgonFetch.Infrastructure.Services;
 
 public class ApplicationInfoService : IApplicationInfoService
 {
+    private const string UnknownVersion = "unknown";
+
     private readonly string _version;
 
     public ApplicationInfoService()
     {
-        _version = LoadVersionFromPropertiesFile();
+        _version = LoadVersion();
     }
 
     public string GetVersion()
@@ -17,11 +20,50 @@ public class ApplicationInfoService : IApplicationInfoService
         return _version;
     }
 
-    private static string LoadVersionFromPropertiesFile()
+    private static string LoadVersion()
+    {
+        // The version is stamped into the assembly at build time from
+        // application.properties (see ReadVersionFromProperties in ArgonFetch.API.csproj),
+        // so the assembly is the reliable source at runtime - the properties file itself
+        // is not part of the published output.
+        return LoadVersionFromAssembly() ?? LoadVersionFromPropertiesFile() ?? UnknownVersion;
+    }
+
+    private static string? LoadVersionFromAssembly()
+    {
+        var assembly = typeof(ApplicationInfoService).Assembly;
+
+        var informationalVersion = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+
+        // AssemblyInformationalVersion carries the source revision as "0.1.1+<commit sha>"
+        // when SourceLink is active; only the version part is wanted here.
+        if (!string.IsNullOrWhiteSpace(informationalVersion))
+        {
+            var version = informationalVersion.Split('+', 2)[0];
+            if (!string.IsNullOrWhiteSpace(version))
+            {
+                return version;
+            }
+        }
+
+        var assemblyVersion = assembly.GetName().Version;
+
+        // AssemblyVersion is always four-part; application.properties uses three,
+        // so drop a trailing zero revision to keep the two in sync.
+        return assemblyVersion is null
+            ? null
+            : assemblyVersion.Revision == 0
+                ? assemblyVersion.ToString(3)
+                : assemblyVersion.ToString();
+    }
+
+    private static string? LoadVersionFromPropertiesFile()
     {
         try
         {
-            // Navigate to the root directory where application.properties is located
+            // Development fallback: application.properties lives at the repository root.
             var currentDirectory = Directory.GetCurrentDirectory();
             var propertiesPath = Path.Combine(currentDirectory, "application.properties");
 
@@ -38,17 +80,17 @@ public class ApplicationInfoService : IApplicationInfoService
 
             if (!File.Exists(propertiesPath))
             {
-                return "unknown";
+                return null;
             }
 
             var doc = XDocument.Load(propertiesPath);
             var versionElement = doc.Root?.Element("version");
 
-            return versionElement?.Value ?? "unknown";
+            return string.IsNullOrWhiteSpace(versionElement?.Value) ? null : versionElement.Value;
         }
         catch
         {
-            return "unknown";
+            return null;
         }
     }
 }


### PR DESCRIPTION
Closes #117

## Problem

The footer and `GET /api/App` reported `unknown` on the deployed build while working locally.

`ApplicationInfoService` read `application.properties` off disk at runtime, probing `<cwd>/application.properties` and `<cwd>/../../application.properties`. In the container `cwd` is `/app`, so it looked for `/app/application.properties` and `/application.properties`.

`Dockerfile:29` copies that file into the **`backend-deps` (SDK) stage** only. The final stage copies just `/app/publish` plus the frontend artifacts, so the file never reaches the runtime image and both probes miss.

## Change

Read the version from the assembly, which is already stamped at build time — no runtime file dependency, so it works identically in Docker and locally.

One wrinkle this had to solve: the version was only stamped into `ArgonFetch.API.dll`, but `ApplicationInfoService` lives in `ArgonFetch.Infrastructure`, which carried the SDK default `1.0.0`. Reading its own assembly would have quietly reported the wrong number. So version stamping moved out of `ArgonFetch.API.csproj` into a root `Directory.Build.props` that applies to all four projects.

`application.properties` remains the single source of truth and is kept as a development fallback.

## Verification

All four assemblies now carry the version from `application.properties`:

```
ArgonFetch.API               0.1.1+038c224
ArgonFetch.Application       0.1.1+038c224
ArgonFetch.Infrastructure    0.1.1+038c224
ArgonFetch.Domain            0.1.1+038c224
```

Reflecting over the built `ArgonFetch.Infrastructure.dll` — the exact value the service reads:

```
InformationalVersion : 0.1.1+038c22448c129b72384b7a4ce44f1cf295e745e4
After split on '+'   : 0.1.1
```

`AppController` prefixes it, so the footer will read `v0.1.1`. `dotnet build` succeeds with no new warnings.
