### PR TITLE
refactor: drop duplicate service provider and fix Swagger title

### DIFF
--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -118,21 +118,21 @@ builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBeh
 
 #region CORS Configuration
 // Configure CORS with environment variable support
+const string defaultCorsOrigin = "http://localhost:4200";
+
+// Get allowed origins from environment variable only
+var allowedOrigins = Environment.GetEnvironmentVariable("CORS_ALLOWED_ORIGINS")?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+    ?? new[] { defaultCorsOrigin }; // Default for development
+
+// In production, ensure we have proper origins configured. The warning is emitted
+// after the host is built so it can use the application's own logger - resolving
+// one here would require building a second service provider (ASP0000).
+var corsUsesDevelopmentDefault = allowedOrigins.Length == 1 && allowedOrigins[0] == defaultCorsOrigin;
+
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(corsBuilder =>
     {
-        // Get allowed origins from environment variable only
-        var allowedOrigins = Environment.GetEnvironmentVariable("CORS_ALLOWED_ORIGINS")?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            ?? new[] { "http://localhost:4200" }; // Default for development
-
-        // In production, ensure we have proper origins configured
-        if (builder.Environment.IsProduction() && allowedOrigins.Length == 1 && allowedOrigins[0] == "http://localhost:4200")
-        {
-            var logger = builder.Services.BuildServiceProvider().GetRequiredService<ILogger<Program>>();
-            logger.LogWarning("CORS is using default localhost origin in production. Please set CORS_ALLOWED_ORIGINS environment variable.");
-        }
-
         corsBuilder.WithOrigins(allowedOrigins);
         corsBuilder.WithExposedHeaders("Content-Disposition");
         corsBuilder.AllowAnyHeader();
@@ -156,6 +156,11 @@ const int maxRetries = 10;
 const int retryDelaySeconds = 5;
 
 var startupLogger = app.Services.GetRequiredService<ILogger<Program>>();
+
+if (app.Environment.IsProduction() && corsUsesDevelopmentDefault)
+{
+    startupLogger.LogWarning("CORS is using default localhost origin in production. Please set CORS_ALLOWED_ORIGINS environment variable.");
+}
 
 while (!dbConnected && retryCount < maxRetries)
 {
@@ -251,7 +256,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI(c =>
     {
-        c.SwaggerEndpoint("/swagger/v1/swagger.json", "DockiUp API V1");
+        c.SwaggerEndpoint("/swagger/v1/swagger.json", "ArgonFetch API V1");
     });
 }
 


### PR DESCRIPTION
Closes #131

## 1. `BuildServiceProvider()` in CORS configuration

```csharp
var logger = builder.Services.BuildServiceProvider().GetRequiredService<ILogger<Program>>();
logger.LogWarning("CORS is using default localhost origin in production. ...");
```

This built an entire second DI container — with its own copy of every singleton — to emit one warning. The compiler flagged it as `ASP0000`.

The origin list and the "is this the dev default" check are now computed once before `AddCors`, and the warning moved to just after `builder.Build()` where the application's real logger is already being resolved for the database retry loop. Same behaviour, one container.

## 2. Wrong product name in Swagger UI

`"DockiUp API V1"` → `"ArgonFetch API V1"`.

## Verification

`dotnet build` succeeds and `ASP0000` no longer appears in the output.
