### PR TITLE
refactor: log exceptions in FetchController instead of discarding them

### DIFF
--- a/src/ArgonFetch.API/Controllers/FetchController.cs
+++ b/src/ArgonFetch.API/Controllers/FetchController.cs
@@ -10,9 +10,12 @@ namespace ArgonFetch.API.Controllers
     public class FetchController : ControllerBase
     {
         private readonly IMediator _mediator;
-        public FetchController(IMediator mediator)
+        private readonly ILogger<FetchController> _logger;
+
+        public FetchController(IMediator mediator, ILogger<FetchController> logger)
         {
             _mediator = mediator;
+            _logger = logger;
         }
 
         [HttpGet("GetResource", Name = "GetResource")]
@@ -30,6 +33,8 @@ namespace ArgonFetch.API.Controllers
             }
             catch (ArgumentException ex)
             {
+                _logger.LogWarning(ex, "Resource not found for {Url}", url);
+
                 return NotFound(new ProblemDetails
                 {
                     Title = "Resource Not Found",
@@ -38,6 +43,8 @@ namespace ArgonFetch.API.Controllers
             }
             catch (NotSupportedException ex)
             {
+                _logger.LogWarning(ex, "Unsupported media type for {Url}", url);
+
                 return StatusCode(StatusCodes.Status415UnsupportedMediaType, new ProblemDetails
                 {
                     Title = "Unsupported Media Type",
@@ -46,6 +53,8 @@ namespace ArgonFetch.API.Controllers
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Failed to fetch {Url}", url);
+
                 return StatusCode(StatusCodes.Status502BadGateway, new ProblemDetails
                 {
                     Title = "Fetch Failed",


### PR DESCRIPTION
Closes #125

## Problem

`FetchController.GetResource` caught three exception types and discarded every one:

```csharp
catch (Exception ex)
{
    return StatusCode(StatusCodes.Status502BadGateway, new ProblemDetails
    {
        Title = "Fetch Failed",
        Status = StatusCodes.Status502BadGateway
    });
}
```

`ex` was bound and never used — the compiler emitted `warning CS0168` three times. Nothing was logged and `ProblemDetails.Detail` was left empty, so an upstream 403, a yt-dlp crash, and a null reference all surfaced identically as a bare `502 Fetch Failed`.

## Change

Inject `ILogger<FetchController>` and log each exception, including the requested URL since these failures are nearly always input-specific:

- `ArgumentException` → `LogWarning` (expected: resource genuinely not found)
- `NotSupportedException` → `LogWarning` (expected: unsupported platform)
- `Exception` → `LogError` (unexpected)

Response bodies are unchanged, so nothing new is exposed to callers — the detail goes to the server log only.

## Verification

`dotnet build` succeeds and the three `CS0168` warnings are gone.

## Note

The commented-out `DownloadResource` block below has the same pattern. Left as-is here rather than widening the diff — it's dead code either way and should probably just be deleted.
