### PR TITLE
fix: stop injecting a null SpotifyClient

### DIFF
--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -74,25 +74,28 @@ builder.Services.AddEndpointsApiExplorer();
 
 #region External Services Configuration
 // Register SpotifyAPI
-builder.Services.AddScoped<SpotifyClient>(sp =>
+// Spotify support is optional. The provider is always resolvable so handlers can be
+// constructed for non-Spotify requests; it reports whether a client is available
+// rather than handing out null.
+builder.Services.AddScoped<ArgonFetch.Application.Services.SpotifyClientProvider>(sp =>
 {
     var config = sp.GetRequiredService<IConfiguration>();
 
     // Use Configuration pattern consistently - same as ConnectionStrings
-    string clientId = config["Spotify:ClientId"];
-    string clientSecret = config["Spotify:ClientSecret"];
+    string? clientId = config["Spotify:ClientId"];
+    string? clientSecret = config["Spotify:ClientSecret"];
 
     if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
     {
         var logger = sp.GetRequiredService<ILogger<Program>>();
         logger.LogWarning("Spotify API credentials not configured. Spotify features will be disabled.");
-        return null;
+        return new ArgonFetch.Application.Services.SpotifyClientProvider(null);
     }
 
     var spotifyConfig = SpotifyClientConfig
        .CreateDefault()
        .WithAuthenticator(new ClientCredentialsAuthenticator(clientId, clientSecret));
-    return new SpotifyClient(spotifyConfig);
+    return new ArgonFetch.Application.Services.SpotifyClientProvider(new SpotifyClient(spotifyConfig));
 });
 
 // Register YoutubeMusicAPI and YoutubeDL

--- a/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
@@ -25,7 +25,7 @@ namespace ArgonFetch.Application.Queries
     public class GetMediaQueryHandler : IRequestHandler<GetMediaQuery, ResourceInformationDto>
     {
         private readonly YoutubeDL _youtubeDL;
-        private readonly SpotifyClient _spotifyClient;
+        private readonly SpotifyClientProvider _spotifyClientProvider;
         private readonly YTMusicAPI.SearchClient _ytmSearchClient;
         private readonly TikTokDllFetcherService _tikTokDllFetcherService;
         private readonly IMemoryCache _memoryCache;
@@ -35,7 +35,7 @@ namespace ArgonFetch.Application.Queries
         private readonly IProxyUrlBuilder _proxyUrlBuilder;
 
         public GetMediaQueryHandler(
-            SpotifyClient spotifyClient,
+            SpotifyClientProvider spotifyClientProvider,
             YTMusicAPI.SearchClient ytmSearchClient,
             YoutubeDL youtubeDL,
             TikTokDllFetcherService tikTokDllFetcherService,
@@ -46,7 +46,7 @@ namespace ArgonFetch.Application.Queries
             IProxyUrlBuilder proxyUrlBuilder
             )
         {
-            _spotifyClient = spotifyClient;
+            _spotifyClientProvider = spotifyClientProvider;
             _ytmSearchClient = ytmSearchClient;
             _youtubeDL = youtubeDL;
             _tikTokDllFetcherService = tikTokDllFetcherService;
@@ -315,9 +315,11 @@ namespace ArgonFetch.Application.Queries
 
         private async Task<ResourceInformationDto> HandleSpotify(string query, CancellationToken cancellationToken)
         {
+            var spotifyClient = _spotifyClientProvider.Require();
+
             var uri = new Uri(query);
             var segments = uri.Segments;
-            var searchResponse = await _spotifyClient.Tracks.Get(segments.Last(), cancellationToken);
+            var searchResponse = await spotifyClient.Tracks.Get(segments.Last(), cancellationToken);
 
             if (searchResponse == null)
                 throw new ArgumentException("Track not found");

--- a/src/ArgonFetch.Application/Services/SpotifyClientProvider.cs
+++ b/src/ArgonFetch.Application/Services/SpotifyClientProvider.cs
@@ -1,0 +1,33 @@
+using SpotifyAPI.Web;
+
+namespace ArgonFetch.Application.Services
+{
+    /// <summary>
+    /// Holds the Spotify client, which is only available when credentials are configured.
+    /// Spotify support is optional, so this wrapper is always resolvable from DI and
+    /// callers check <see cref="IsConfigured"/> - registering a null SpotifyClient
+    /// directly would inject null into every consumer instead.
+    /// </summary>
+    public sealed class SpotifyClientProvider
+    {
+        public SpotifyClientProvider(SpotifyClient? client)
+        {
+            Client = client;
+        }
+
+        public SpotifyClient? Client { get; }
+
+        public bool IsConfigured => Client is not null;
+
+        /// <summary>
+        /// Returns the configured client, or throws a descriptive error when Spotify
+        /// credentials are missing.
+        /// </summary>
+        public SpotifyClient Require()
+        {
+            return Client ?? throw new NotSupportedException(
+                "Spotify support is not configured on this instance. " +
+                "Set the Spotify:ClientId and Spotify:ClientSecret configuration values to enable it.");
+        }
+    }
+}


### PR DESCRIPTION
Closes #124

## Problem

```csharp
builder.Services.AddScoped<SpotifyClient>(sp =>
{
    if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
    {
        logger.LogWarning("Spotify API credentials not configured. ...");
        return null;   // CS8603
    }
    ...
});
```

`GetMediaQueryHandler` declared `SpotifyClient` as a non-nullable constructor dependency, so the null was injected anyway and `_spotifyClient.Tracks.Get(...)` threw a `NullReferenceException` on the first Spotify request. `FetchController` caught it and returned a generic `502 Fetch Failed` with nothing logged, so the actual cause — "you never configured Spotify" — was invisible.

## Change

A `SpotifyClientProvider` wrapper that is always resolvable and reports availability instead of handing out null:

```csharp
public sealed class SpotifyClientProvider
{
    public SpotifyClient? Client { get; }
    public bool IsConfigured => Client is not null;
    public SpotifyClient Require() => Client ?? throw new NotSupportedException(...);
}
```

`HandleSpotify` calls `Require()`, which throws a `NotSupportedException` naming the two missing configuration keys. `FetchController` already maps that to `415 Unsupported Media Type` — accurate here, since the instance genuinely can't serve Spotify — instead of an opaque 502.

## Why a wrapper rather than a nullable parameter

Making the constructor parameter `SpotifyClient?` would not have helped: MS DI ignores nullability annotations, so the null still flows in and every future consumer has to remember to check. Not registering the service at all would break handler construction for *non*-Spotify requests too. The wrapper makes "configured or not" part of the type.

The non-Spotify paths are untouched — handlers still construct fine when Spotify is unconfigured.

## Verification

`dotnet build` succeeds. `CS8603` and the two `CS8600` warnings in `Program.cs` are gone; the three remaining `CS8603` warnings are pre-existing ones in `MediaValidators.cs`, out of scope here.
