### PR TITLE
fix: never restart a download that has already written output

### DIFF
--- a/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
@@ -26,20 +26,17 @@ namespace ArgonFetch.Application.Queries
         private readonly IMediaUrlCacheService _cacheService;
         private readonly IFfmpegStreamingService _ffmpegStreamingService;
         private readonly IAcceleratedDownloadService _acceleratedDownloadService;
-        private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<StreamMediaQueryHandler> _logger;
 
         public StreamMediaQueryHandler(
             IMediaUrlCacheService cacheService,
             IFfmpegStreamingService ffmpegStreamingService,
             IAcceleratedDownloadService acceleratedDownloadService,
-            IHttpClientFactory httpClientFactory,
             ILogger<StreamMediaQueryHandler> logger)
         {
             _cacheService = cacheService;
             _ffmpegStreamingService = ffmpegStreamingService;
             _acceleratedDownloadService = acceleratedDownloadService;
-            _httpClientFactory = httpClientFactory;
             _logger = logger;
         }
 
@@ -103,35 +100,14 @@ namespace ArgonFetch.Application.Queries
                     // Note: We don't set Content-Length as we might be chunking
                     // The accelerated download will handle range requests if supported
 
-                    try
-                    {
-                        // Use accelerated download service for better speed
-                        await _acceleratedDownloadService.StreamWithAccelerationAsync(
-                            mediaUrl,
-                            request.Response.Body,
-                            null, // No progress reporting needed here
-                            request.CancellationToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning(ex, "Accelerated download failed, falling back to single connection");
-
-                        // Fallback to single connection if accelerated fails
-                        var httpClient = _httpClientFactory.CreateClient();
-                        httpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
-
-                        using var response = await httpClient.GetAsync(
-                            mediaUrl,
-                            HttpCompletionOption.ResponseHeadersRead,
-                            request.CancellationToken);
-
-                        if (!response.IsSuccessStatusCode)
-                        {
-                            return StreamResult.BadGateway($"Failed to fetch media: {response.ReasonPhrase}");
-                        }
-
-                        await response.Content.CopyToAsync(request.Response.Body, request.CancellationToken);
-                    }
+                    // The service already falls back to a single connection internally, and only
+                    // while doing so is still safe. Retrying here would append a second copy of
+                    // the file to a response body that may already hold part of one.
+                    await _acceleratedDownloadService.StreamWithAccelerationAsync(
+                        mediaUrl,
+                        request.Response.Body,
+                        null, // No progress reporting needed here
+                        request.CancellationToken);
                 }
 
                 return StreamResult.Success();

--- a/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
@@ -36,42 +36,86 @@ namespace ArgonFetch.Infrastructure.Services
             IProgress<double>? progress = null,
             CancellationToken cancellationToken = default)
         {
+            // Counts what has already been handed to the caller. Once any byte is written,
+            // restarting the download would append a second copy of the file, so a failure
+            // past that point has to propagate rather than fall back.
+            var output = new OutputTracker();
+
+            // Probe for range support first. This writes nothing, so failing here is
+            // always safe to recover from.
+            long? contentLength = null;
+            var acceptsRanges = false;
+            var probeSucceeded = false;
+
             try
             {
-                // First, check if the server supports range requests
                 var httpClient = _httpClientFactory.CreateClient();
                 httpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
 
                 using var headRequest = new HttpRequestMessage(HttpMethod.Head, url);
                 using var headResponse = await httpClient.SendAsync(headRequest, cancellationToken);
 
-                if (!headResponse.IsSuccessStatusCode)
+                if (headResponse.IsSuccessStatusCode)
                 {
-                    _logger.LogWarning("HEAD request failed, falling back to single connection download");
-                    await DownloadSingleConnectionAsync(url, outputStream, progress, cancellationToken);
-                    return;
+                    contentLength = headResponse.Content.Headers.ContentLength;
+                    acceptsRanges = headResponse.Headers.AcceptRanges?.Contains("bytes") ?? false;
+                    probeSucceeded = true;
                 }
-
-                var contentLength = headResponse.Content.Headers.ContentLength;
-                var acceptRanges = headResponse.Headers.AcceptRanges?.Contains("bytes") ?? false;
-
-                if (!contentLength.HasValue || !acceptRanges)
+                else
                 {
-                    _logger.LogInformation("Server doesn't support range requests, using single connection");
-                    await DownloadSingleConnectionAsync(url, outputStream, progress, cancellationToken);
-                    return;
+                    _logger.LogWarning("HEAD request failed with {StatusCode}, falling back to single connection download",
+                        (int)headResponse.StatusCode);
                 }
-
-                _logger.LogInformation("Starting accelerated download with {Connections} connections for {Size} bytes",
-                    MAX_PARALLEL_CONNECTIONS, contentLength.Value);
-
-                await DownloadInChunksAsync(url, outputStream, contentLength.Value, progress, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error during accelerated download, falling back to single connection");
-                await DownloadSingleConnectionAsync(url, outputStream, progress, cancellationToken);
+                _logger.LogWarning(ex, "Range support probe failed, falling back to single connection download");
             }
+
+            if (!probeSucceeded || !contentLength.HasValue || !acceptsRanges)
+            {
+                if (probeSucceeded)
+                {
+                    _logger.LogInformation("Server doesn't support range requests, using single connection");
+                }
+
+                await DownloadSingleConnectionAsync(url, outputStream, progress, output, cancellationToken);
+                return;
+            }
+
+            _logger.LogInformation("Starting accelerated download with {Connections} connections for {Size} bytes",
+                MAX_PARALLEL_CONNECTIONS, contentLength.Value);
+
+            try
+            {
+                await DownloadInChunksAsync(url, outputStream, contentLength.Value, progress, output, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // The caller went away or the request was aborted; retrying is pointless.
+                throw;
+            }
+            catch (Exception ex) when (output.BytesWritten == 0)
+            {
+                // Nothing has reached the caller yet, so starting over is safe.
+                _logger.LogWarning(ex, "Accelerated download failed before writing any output, falling back to single connection");
+                await DownloadSingleConnectionAsync(url, outputStream, progress, output, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Tracks how much of the output stream has already been written, so callers can tell
+        /// whether restarting a transfer would duplicate bytes the consumer has already seen.
+        /// </summary>
+        private sealed class OutputTracker
+        {
+            public long BytesWritten { get; private set; }
+
+            public void Add(long count) => BytesWritten += count;
         }
 
         private async Task DownloadInChunksAsync(
@@ -79,6 +123,7 @@ namespace ArgonFetch.Infrastructure.Services
             Stream outputStream,
             long contentLength,
             IProgress<double>? progress,
+            OutputTracker output,
             CancellationToken cancellationToken)
         {
             var chunkSize = Math.Max(DEFAULT_CHUNK_SIZE, contentLength / (MAX_PARALLEL_CONNECTIONS * 2));
@@ -125,6 +170,9 @@ namespace ArgonFetch.Infrastructure.Services
             {
                 if (chunkData.TryGetValue(i, out var data))
                 {
+                    // Counted before the write: a write that throws may still have pushed
+                    // bytes to the consumer, so the output can no longer be restarted.
+                    output.Add(data.Length);
                     await outputStream.WriteAsync(data, 0, data.Length, cancellationToken);
                 }
             }
@@ -155,6 +203,7 @@ namespace ArgonFetch.Infrastructure.Services
             string url,
             Stream outputStream,
             IProgress<double>? progress,
+            OutputTracker output,
             CancellationToken cancellationToken)
         {
             var httpClient = _httpClientFactory.CreateClient();
@@ -172,6 +221,7 @@ namespace ArgonFetch.Infrastructure.Services
 
             while ((bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) != 0)
             {
+                output.Add(bytesRead);
                 await outputStream.WriteAsync(buffer, 0, bytesRead, cancellationToken);
                 totalBytesRead += bytesRead;
 


### PR DESCRIPTION
Closes #118

## Problem

`StreamWithAccelerationAsync` wrapped the entire transfer in a blanket catch and retried into the **same** output stream:

```csharp
catch (Exception ex)
{
    _logger.LogError(ex, "Error during accelerated download, falling back to single connection");
    await DownloadSingleConnectionAsync(url, outputStream, progress, cancellationToken);
}
```

Two problems:

1. If the transfer failed *after* writing, the fallback appended a second full copy of the file to a response body that already held part of one.
2. `OperationCanceledException` was caught too, so a client disconnect restarted the whole download instead of aborting.

`StreamMediaQueryHandler` wrapped the same call in a second, identical fallback with the same hazard.

## Change

- The range-support probe (HEAD) is separated from the transfer. It writes nothing, so failing there can always fall back safely.
- An `OutputTracker` counts bytes handed to the output stream. The fallback is guarded by an exception filter, `when (output.BytesWritten == 0)`, so once anything has been written the exception propagates instead.
- Cancellation propagates.
- The duplicate fallback in `StreamMediaQueryHandler` is removed, along with the now-unused `IHttpClientFactory` dependency.

## Verification

Tested against the real service with a range-capable local HTTP server that can inject failures.

| Case | Result |
|---|---|
| A: ranges supported, no failures | completed, 5000000 bytes, byte-identical |
| B: 3rd range request returns 500 | completed, 5000000 bytes, byte-identical (fell back once) |
| C: server advertises no range support | completed, 5000000 bytes, byte-identical |
| D: output stream fails mid-write | **threw IOException, 0 further write attempts** |
| E: cancelled mid-download | **threw OperationCanceledException, 0 bytes written** |

D and E are the cases that actually distinguish this from the old behaviour. A–C pass on `main` too.

### The test caught a bug in the first version of this fix

I initially incremented the tracker *after* `WriteAsync`. When the sink threw, the counter was still zero, the filter matched, and the fallback ran anyway — case D reported `write attempts after failure: 1`, i.e. it was still writing into a broken stream. Counting *before* the write fixes it, and is the correct semantics regardless: a write that throws may still have pushed bytes to the consumer. Case D now reports `0`.

Note the test server needed `ThreadingHTTPServer` — the single-threaded version deadlocks on the parallel range requests and produced a misleading first result.

## Scope notes

- The silent `TryGetValue` skip in the write loop (a missing chunk yields a truncated file with a 200) is left to #119, which rewrites that loop.
- On `main` this manifests purely as body corruption. The `Content-Length` mismatch described in the issue comes from the in-flight #116 work, which sets `Response.ContentLength` on this path.
