### PR TITLE
ci: build the frontend on Node 22 instead of Node 18

### DIFF
--- a/src/ArgonFetch.API/Dockerfile
+++ b/src/ArgonFetch.API/Dockerfile
@@ -45,7 +45,7 @@ RUN dotnet publish "ArgonFetch.API.csproj" \
     /p:UseAppHost=false
 
 # Stage 4: Frontend dependencies
-FROM node:18-alpine AS frontend-deps
+FROM node:22-alpine AS frontend-deps
 WORKDIR /src/frontend
 COPY src/ArgonFetch.Frontend/package*.json ./
 RUN npm ci --prefer-offline --no-audit --no-fund


### PR DESCRIPTION
Closes #129

## Change

```diff
-FROM node:18-alpine AS frontend-deps
+FROM node:22-alpine AS frontend-deps
```

Node 18 reached end of life in April 2025. Beyond being unsupported today, Angular 20+ requires `^20.19 || ^22.12 || ^24`, so the image build would have broken the moment the Angular upgrade in #128 landed.

Node 22 is an active LTS and satisfies both the current Angular 19 and the 20/21 hops. There is no `engines` field in `package.json` pinning anything narrower.

## Verification

Built the actual Docker stage rather than assuming:

```
docker build -f src/ArgonFetch.API/Dockerfile --target frontend-build .
```

```
Application bundle generation complete. [2.341 seconds]
Output location: /.artifacts/frontend
main-V777OZFI.js      | main          | 410.55 kB
polyfills-FFHMD2TL.js | polyfills     |  34.52 kB
styles-VGJFK2Z6.css   | styles        |   1.00 kB
```

`npm ci` and `npm run build:agent` both succeed on Node 22.

## Note

If Angular 22 turns out to require Node 24, #128 should bump this again — worth re-checking at that point rather than jumping ahead now.
