### PR TITLE
fix: update packages with known vulnerabilities

### DIFF
--- a/src/ArgonFetch.Application/ArgonFetch.Application.csproj
+++ b/src/ArgonFetch.Application/ArgonFetch.Application.csproj
@@ -13,14 +13,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.2.0" />
+    <PackageReference Include="AngleSharp" Version="1.7.1" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
     <PackageReference Include="SpotifyAPI.Web" Version="7.2.1" />
-    <PackageReference Include="YoutubeDLSharp" Version="1.1.1" />
+    <PackageReference Include="YoutubeDLSharp" Version="1.2.0" />
     <PackageReference Include="YTMusicAPI" Version="1.0.7" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #126

## Change

| Package | From | To | Advisory | Severity | First patched |
|---|---|---|---|---|---|
| YoutubeDLSharp | 1.1.1 | 1.2.0 | [GHSA-2jh5-g5ch-43q5](https://github.com/advisories/GHSA-2jh5-g5ch-43q5) | **Critical** | 1.1.2 |
| AngleSharp | 1.2.0 | 1.7.1 | [GHSA-pgww-w46g-26qg](https://github.com/advisories/GHSA-pgww-w46g-26qg) | Moderate | 1.5.0 |

Both are declared in `src/ArgonFetch.Application/ArgonFetch.Application.csproj`.

The YoutubeDLSharp one is worth calling out: *"command injection on windows system due to non sanitized arguments"*, affecting `>= 1.0.0-beta4, < 1.1.2`. That package is on the media-fetch path that handles user-supplied URLs, and the dev environment here is Windows.

Both are bumped past the minimum patched version to current latest stable, since the build is clean on both.

## Verification

`dotnet build` succeeds with no `NU1902`/`NU1904` warnings, and:

```
$ dotnet list package --vulnerable --include-transitive
Für das angegebene Projekt "ArgonFetch.API" liegen gemäß den aktuellen Quellen
keine anfälligen Pakete vor.
```

(No vulnerable packages for the given project.)

The jump to YoutubeDLSharp 1.2.0 crosses a minor version, but the API surface this project uses compiles unchanged. Worth a smoke test of an actual download before merging, since the build alone can't confirm runtime behaviour of the yt-dlp wrapper — I couldn't run that end-to-end here without live URLs.
