### PR TITLE
perf: stream chunked downloads instead of buffering the whole file

### DIFF
--- a/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
@@ -1,6 +1,5 @@
 using ArgonFetch.Application.Interfaces;
 using Microsoft.Extensions.Logging;
-using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 
 namespace ArgonFetch.Infrastructure.Services
@@ -9,7 +8,11 @@ namespace ArgonFetch.Infrastructure.Services
     {
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<AcceleratedDownloadService> _logger;
-        private const int DEFAULT_CHUNK_SIZE = 2 * 1024 * 1024; // 2MB chunks
+        private const int MIN_CHUNK_SIZE = 2 * 1024 * 1024; // 2MB chunks
+        // Chunk size is capped so the sliding window below stays bounded. Without a cap it
+        // scales with the file, and the window along with it - a 2GB download would hold
+        // roughly 1GB in memory.
+        private const int MAX_CHUNK_SIZE = 8 * 1024 * 1024; // 8MB chunks
         private const int MAX_PARALLEL_CONNECTIONS = 8; // Maximum parallel connections
 
         public AcceleratedDownloadService(
@@ -126,7 +129,7 @@ namespace ArgonFetch.Infrastructure.Services
             OutputTracker output,
             CancellationToken cancellationToken)
         {
-            var chunkSize = Math.Max(DEFAULT_CHUNK_SIZE, contentLength / (MAX_PARALLEL_CONNECTIONS * 2));
+            var chunkSize = Math.Clamp(contentLength / (MAX_PARALLEL_CONNECTIONS * 2), MIN_CHUNK_SIZE, MAX_CHUNK_SIZE);
             var chunks = new List<(long start, long end)>();
 
             // Calculate chunks
@@ -136,45 +139,52 @@ namespace ArgonFetch.Infrastructure.Services
                 chunks.Add((i, end));
             }
 
-            _logger.LogInformation("Downloading {ChunkCount} chunks of ~{ChunkSize} bytes each",
+            _logger.LogInformation("Downloading {ChunkCount} chunks of ~{ChunkSizeMb} MB each",
                 chunks.Count, chunkSize / 1024 / 1024);
 
-            // Download chunks in parallel
-            var chunkData = new ConcurrentDictionary<int, byte[]>();
+            // Sliding window: at most MAX_PARALLEL_CONNECTIONS chunks are downloading or
+            // waiting to be written at any moment, so peak memory is bounded by the window
+            // rather than by the size of the file. Chunks are written in order and their
+            // buffers released as soon as they reach the output stream, which also means the
+            // consumer starts receiving data before the last chunk has arrived.
+            var inFlight = new Queue<Task<byte[]>>(MAX_PARALLEL_CONNECTIONS);
+            var nextToStart = 0;
             var totalBytesDownloaded = 0L;
 
-            using var semaphore = new SemaphoreSlim(MAX_PARALLEL_CONNECTIONS);
-            var downloadTasks = chunks.Select(async (chunk, index) =>
+            try
             {
-                await semaphore.WaitAsync(cancellationToken);
-                try
+                for (var index = 0; index < chunks.Count; index++)
                 {
-                    var data = await DownloadChunkAsync(url, chunk.start, chunk.end, cancellationToken);
-                    chunkData[index] = data;
+                    while (inFlight.Count < MAX_PARALLEL_CONNECTIONS && nextToStart < chunks.Count)
+                    {
+                        var chunk = chunks[nextToStart++];
+                        inFlight.Enqueue(DownloadChunkAsync(url, chunk.start, chunk.end, cancellationToken));
+                    }
 
-                    var downloaded = Interlocked.Add(ref totalBytesDownloaded, data.Length);
-                    progress?.Report((double)downloaded / contentLength);
+                    var data = await inFlight.Dequeue();
 
-                    _logger.LogDebug("Downloaded chunk {Index} ({Start}-{End})", index, chunk.start, chunk.end);
-                }
-                finally
-                {
-                    semaphore.Release();
-                }
-            }).ToArray();
-
-            await Task.WhenAll(downloadTasks);
-
-            // Write chunks to output stream in order
-            for (int i = 0; i < chunks.Count; i++)
-            {
-                if (chunkData.TryGetValue(i, out var data))
-                {
                     // Counted before the write: a write that throws may still have pushed
                     // bytes to the consumer, so the output can no longer be restarted.
                     output.Add(data.Length);
                     await outputStream.WriteAsync(data, 0, data.Length, cancellationToken);
+
+                    totalBytesDownloaded += data.Length;
+                    progress?.Report((double)totalBytesDownloaded / contentLength);
+
+                    _logger.LogDebug("Wrote chunk {Index} ({Start}-{End})",
+                        index, chunks[index].start, chunks[index].end);
                 }
+            }
+            catch
+            {
+                // Observe the downloads still running so their failures don't resurface
+                // later as unobserved task exceptions.
+                foreach (var pending in inFlight)
+                {
+                    _ = pending.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+                }
+
+                throw;
             }
 
             await outputStream.FlushAsync(cancellationToken);


### PR DESCRIPTION
Closes #119

> **Stacked on #118** — base branch is `feature/118_FixCorruptDownloadFallback`, not `main`. See "Why this is stacked" below. Merge #118 first, then this retargets to `main` cleanly.

## Problem

`DownloadInChunksAsync` collected every chunk into a `ConcurrentDictionary<int, byte[]>` and only started writing once all of them had arrived. Peak memory tracked the size of the file, and the consumer received nothing until the last chunk landed.

## Change

A sliding window: at most `MAX_PARALLEL_CONNECTIONS` chunks are downloading or waiting to be written at any moment, and each buffer is released as soon as it reaches the output stream. Chunks are still written in order, so output is byte-identical.

**Chunk size is now clamped, not just floored.** This turned out to matter more than the window itself:

```diff
-var chunkSize = Math.Max(DEFAULT_CHUNK_SIZE, contentLength / (MAX_PARALLEL_CONNECTIONS * 2));
+var chunkSize = Math.Clamp(contentLength / (MAX_PARALLEL_CONNECTIONS * 2), MIN_CHUNK_SIZE, MAX_CHUNK_SIZE);
```

The old expression scales with the file — a 2 GB download meant 128 MB chunks, so an 8-deep window would still have held ~1 GB. I only caught this because the first measurement of the "fixed" version still showed 375 MB peak for a 200 MB file.

Two smaller things in the same loop:

- The silent `if (chunkData.TryGetValue(i, out var data))` skip is gone. It turned a missing chunk into a truncated file served with a `200`.
- Downloads still in flight when the loop throws are now observed, so they don't resurface as unobserved task exceptions.

## Verification

Measured against the real service over a local range-capable HTTP server. Peak is **live** heap — the sampler calls `GC.GetTotalMemory(true)`, forcing a collection, so this is bytes actually retained rather than allocation churn.

| Payload | `main` peak live | this branch | output |
|---|---|---|---|
| 200 MB | **212 MB** | **56 MB** | sha256 identical |
| 600 MB | **628 MB** | **64 MB** | sha256 identical |

`main` tracks the file size almost exactly (212 MB for 200 MB, 628 MB for 600 MB). This branch stays flat at roughly the window size (8 × 8 MB) as the payload triples.

SHA-256 of the downloaded bytes matches the server's hash in every run. Wall clock is unchanged to slightly better (157 ms vs 186 ms at 200 MB).

The correctness cases from #118 (range failure → fallback, no range support → single connection, cancellation, mid-write failure) still pass on this branch.

## Why this is stacked on #118

Interleaving writes with downloads means bytes reach the client early and often. On `main`, `StreamWithAccelerationAsync` still catches everything and re-downloads into the same stream — combined with this change that makes duplicate-append *more* likely, not less. #118 adds the guard that makes it safe, so shipping this on its own would be a regression.
