### PR TITLE
refactor: type the download component against the generated API client

### DIFF
--- a/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.ts
+++ b/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.ts
@@ -103,7 +103,7 @@ export class SingleSongContainerComponent {
 
     if (type === 'combined') {
       // Handle video streams (with audio)
-      const videoRef = mediaItem.video as any; // Cast to any since the API models might not be updated yet
+      const videoRef = mediaItem.video;
       if (!videoRef) {
         console.error('No video references available');
         return;
@@ -113,7 +113,7 @@ export class SingleSongContainerComponent {
       extension = this.resourceUrlService.getFileExtension(videoRef, quality) || '.mp4';
     } else if (type === 'audio') {
       // Handle audio-only streams
-      const audioRef = mediaItem.audio as any; // Cast to any since the API models might not be updated yet
+      const audioRef = mediaItem.audio;
       if (!audioRef) {
         console.error('No audio references available');
         return;
@@ -145,13 +145,14 @@ export class SingleSongContainerComponent {
     this.totalBytes = 0;
     this.downloadedMB = '0';
 
-    try {
-      // Use HttpClient to download with progress tracking
-      this.http.get(url, {
-        responseType: 'blob',
-        reportProgress: true,
-        observe: 'events'
-      }).subscribe({
+    // Use HttpClient to download with progress tracking.
+    // Errors arrive on the error callback, not as a thrown exception - subscribe()
+    // returns as soon as the request is issued.
+    this.http.get(url, {
+      responseType: 'blob',
+      reportProgress: true,
+      observe: 'events'
+    }).subscribe({
         next: (event) => {
           if (event.type === HttpEventType.DownloadProgress) {
             // Store total bytes if available
@@ -226,33 +227,23 @@ export class SingleSongContainerComponent {
             if (blob) {
               this.saveBlob(blob, filename);
             }
-            this.isDownloading = false;
-            this.downloadProgress = 0;
-            this.currentDownloadName = '';
-            this.downloadSpeed = '';
-            this.totalBytes = 0;
-            this.downloadedMB = '';
+            this.resetDownloadState();
           }
         },
         error: (error) => {
           console.error('Download failed:', error);
-          this.isDownloading = false;
-          this.downloadProgress = 0;
-          this.currentDownloadName = '';
-          this.downloadSpeed = '';
-          this.totalBytes = 0;
-          this.downloadedMB = '';
+          this.resetDownloadState();
         }
       });
-    } catch (error) {
-      console.error('Download error:', error);
-      this.isDownloading = false;
-      this.downloadProgress = 0;
-      this.currentDownloadName = '';
-      this.downloadSpeed = '';
-      this.totalBytes = 0;
-      this.downloadedMB = '';
-    }
+  }
+
+  private resetDownloadState() {
+    this.isDownloading = false;
+    this.downloadProgress = 0;
+    this.currentDownloadName = '';
+    this.downloadSpeed = '';
+    this.totalBytes = 0;
+    this.downloadedMB = '';
   }
 
   private saveBlob(blob: Blob, filename: string) {

--- a/src/ArgonFetch.Frontend/src/app/services/resource-url.service.ts
+++ b/src/ArgonFetch.Frontend/src/app/services/resource-url.service.ts
@@ -1,27 +1,12 @@
 import { Injectable } from '@angular/core';
 import { environment } from '../../environments/environment';
+import { StreamReferenceDto, UrlType } from '../api';
 
-// Mirrors ArgonFetch.Application.Enums.UrlType, serialized by name.
-export enum UrlType {
-  Combined = 'Combined',
-  Media = 'Media'
-}
-
-export interface StreamReferenceDto {
-  bestQualityDescription?: string | null;
-  bestQualityKey?: string | null;
-  bestQualityFileExtension?: string | null;
-
-  mediumQualityDescription?: string | null;
-  mediumQualityKey?: string | null;
-  mediumQualityFileExtension?: string | null;
-
-  worstQualityDescription?: string | null;
-  worstQualityKey?: string | null;
-  worstQualityFileExtension?: string | null;
-
-  urlType: UrlType;
-}
+// StreamReferenceDto and UrlType come from the generated API client rather than being
+// redefined here - the local copies had drifted from the generated ones, which is why
+// callers had to cast through `any` to pass a DTO into this service.
+export type { StreamReferenceDto };
+export { UrlType };
 
 @Injectable({
   providedIn: 'root'


### PR DESCRIPTION
Closes #132

> **Stacked on #123** — base branch is `feature/123_JsonStringEnumConverter`, not `main`. See "Why this is stacked" below.

## 1. `as any` casts

```ts
const videoRef = mediaItem.video as any; // Cast to any since the API models might not be updated yet
```

The comment was out of date — the generated `StreamReferenceDto` already has every field the component reads. The real cause was `ResourceUrlService` declaring its **own** `StreamReferenceDto` and `UrlType`, which had drifted from the generated ones (`urlType` required vs optional, and a different `UrlType` shape). Passing a generated DTO into the service was a type error, so callers cast through `any` — which also silenced any genuine type errors on those field accesses.

Fixed at the source: the service now re-exports the generated types instead of redefining them, and both casts are gone.

## 2. Dead `try`/`catch`

```ts
try {
  this.http.get(...).subscribe({ next: ..., error: ... });
} catch (error) { /* ...six assignments... */ }
```

`subscribe` returns as soon as the request is issued; async failures go to the `error` callback. The catch could never run for the case it was written for.

## 3. Duplicated state reset

The same six assignments appeared three times (response, error, catch). Now one `resetDownloadState()`.

## Why this is stacked on #123

On `main` the generated `UrlType` is still `{ NUMBER_0, NUMBER_1 }`, so `UrlType.Combined` doesn't compile — I hit exactly that error when I first based this on `main`:

```
TS2339: Property 'Combined' does not exist on type '{ NUMBER_0: UrlType; NUMBER_1: UrlType; }'.
```

#123 is what gives those members real names. Basing this on `main` would mean writing `UrlType.NUMBER_0` and immediately un-writing it.

## Verification

`npx ng build` succeeds — which matters here because Angular's compiler is what typechecks the removed casts and the templates; `tsc --noEmit` alone doesn't cover templates.

## Not addressed

The blob-in-memory concern from the issue (a 4K video is held entirely in the tab before `saveBlob`) is a bigger behavioural change and isn't touched here. Worth splitting into its own issue if you want it.
