### PR TITLE
refactor: update PostgreSQL from 15 to 18

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   dev-db:
-    image: postgres:15
+    image: postgres:18
     container_name: argonfetch-postgres-dev
     restart: always
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:15
+    image: postgres:18
     container_name: argonfetch-db
     env_file: .env
     volumes:


### PR DESCRIPTION
Closes #148

## Change

`postgres:15` → `postgres:18` in `compose.yml` and `compose.dev.yml`. 18 is the current major (18.4).

## Verification

Started `postgres:18` and applied the existing migration against it with the Npgsql provider currently on `main`:

```
PostgreSQL 18.4 (Debian 18.4-1.pgdg13+1) on x86_64-pc-linux-gnu

$ dotnet ef database update --connection "Host=localhost;Port=55434;..."
Applying migration '20250924120839_InitialCreate'.
Done.
```

Schema confirmed:

```
 Schema |         Name          | Type
--------+-----------------------+-------
 public | __EFMigrationsHistory | table
```

## ⚠️ This is a breaking change for existing deployments

A Postgres **major** upgrade is not in-place. The on-disk data directory format changes between majors, and Postgres 18 will refuse to start against a directory written by 15:

```
FATAL: database files are incompatible with server
```

Anyone with an existing `postgres_data` / `postgres-data-dev` volume needs a dump/restore or `pg_upgrade` before this lands. Fresh installs are unaffected.

This needs to be in the release notes rather than shipped quietly — worth deciding whether to call it out in the README upgrade section too.
