### PR TITLE
fix: keep yt-dlp updated at runtime

### DIFF
--- a/src/ArgonFetch.API/Dockerfile
+++ b/src/ArgonFetch.API/Dockerfile
@@ -9,9 +9,15 @@ RUN apt-get update && \
         python3 \
         curl \
         ca-certificates && \
-    # Download yt-dlp standalone binary (still needs Python to run)
-    curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp && \
-    chmod a+rx /usr/local/bin/yt-dlp && \
+    # Download yt-dlp standalone binary (still needs Python to run).
+    # It lives in /opt/yt-dlp rather than /usr/local/bin because yt-dlp --update
+    # replaces its own binary in place, which needs the directory and the file to be
+    # writable by the runtime user ($APP_UID), not just by root.
+    mkdir -p /opt/yt-dlp && \
+    curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /opt/yt-dlp/yt-dlp && \
+    chmod 0755 /opt/yt-dlp/yt-dlp && \
+    chown -R $APP_UID:0 /opt/yt-dlp && \
+    ln -s /opt/yt-dlp/yt-dlp /usr/local/bin/yt-dlp && \
     # Verify installations
     yt-dlp --version && \
     ffmpeg -version && \

--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -48,6 +48,9 @@ builder.Services.AddScoped<TikTokDllFetcherService>();
 // Register In memory caching
 builder.Services.AddMemoryCache();
 
+// Keep yt-dlp current at runtime; the image only downloads it at build time.
+builder.Services.AddHostedService<ArgonFetch.Infrastructure.Services.YtDlpUpdateService>();
+
 // Register Application Info Service
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IApplicationInfoService, ArgonFetch.Infrastructure.Services.ApplicationInfoService>();
 #endregion

--- a/src/ArgonFetch.Infrastructure/Services/YtDlpUpdateService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/YtDlpUpdateService.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+
+namespace ArgonFetch.Infrastructure.Services
+{
+    /// <summary>
+    /// Keeps yt-dlp current for the lifetime of the container.
+    /// <para>
+    /// The image only downloads yt-dlp at build time, so a long-running deployment
+    /// otherwise stays pinned to whatever version was current when the image was built.
+    /// yt-dlp releases frequently because extractors break when the upstream sites change,
+    /// so that version degrades until someone rebuilds.
+    /// </para>
+    /// <para>
+    /// Update failures are logged and swallowed: a container with no network access, or one
+    /// hitting a GitHub rate limit, must still start and serve requests with the binary it has.
+    /// </para>
+    /// </summary>
+    public class YtDlpUpdateService : BackgroundService
+    {
+        private static readonly TimeSpan UpdateInterval = TimeSpan.FromHours(12);
+        private static readonly TimeSpan UpdateTimeout = TimeSpan.FromMinutes(5);
+
+        private readonly ILogger<YtDlpUpdateService> _logger;
+
+        public YtDlpUpdateService(ILogger<YtDlpUpdateService> logger)
+        {
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await TryUpdateAsync(stoppingToken);
+
+                try
+                {
+                    await Task.Delay(UpdateInterval, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Shutting down.
+                    return;
+                }
+            }
+        }
+
+        private async Task TryUpdateAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                // Bound the attempt so a hung download can't keep the timer from firing again.
+                using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeout.CancelAfter(UpdateTimeout);
+
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "yt-dlp",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                };
+                startInfo.ArgumentList.Add("--update");
+
+                using var process = new Process { StartInfo = startInfo };
+
+                process.Start();
+
+                var stdoutTask = process.StandardOutput.ReadToEndAsync(timeout.Token);
+                var stderrTask = process.StandardError.ReadToEndAsync(timeout.Token);
+
+                await process.WaitForExitAsync(timeout.Token);
+
+                var stdout = (await stdoutTask).Trim();
+                var stderr = (await stderrTask).Trim();
+
+                if (process.ExitCode == 0)
+                {
+                    _logger.LogInformation("yt-dlp update check: {Output}",
+                        string.IsNullOrWhiteSpace(stdout) ? "already up to date" : stdout);
+                }
+                else
+                {
+                    // Most likely cause is the binary living somewhere the runtime user
+                    // cannot write, which makes the in-place self-update impossible.
+                    _logger.LogWarning(
+                        "yt-dlp update failed with exit code {ExitCode}. Continuing with the installed version. {Error}",
+                        process.ExitCode,
+                        string.IsNullOrWhiteSpace(stderr) ? stdout : stderr);
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "yt-dlp update check could not run. Continuing with the installed version.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #151

## What was actually wrong

There is no autoupdater — `grep` for `RunUpdate` / `--update` / any update call across `src/` returns nothing. yt-dlp is downloaded exactly once, at image build time:

```dockerfile
curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp
```

`releases/latest` resolves at **build** time. After that the container keeps that version forever. yt-dlp ships constantly precisely because extractors break when YouTube changes, so a long-lived deployment degrades until someone rebuilds. `MediaValidators.GetYtDlpVersionAsync()` logs the version at startup but nothing acts on it.

And a second problem that would have defeated a naive fix: the binary was root-owned while the container runs as `$APP_UID` (1654), so the in-place self-update could not write.

## Change

**`YtDlpUpdateService`** — a `BackgroundService` that runs `yt-dlp --update` at startup and every 12 hours. Deliberately defensive:

- failures are logged and swallowed, so a container with no network or a GitHub rate limit still starts and serves
- each attempt is bounded by a 5-minute timeout so a hung download can't block later runs
- stdout/stderr are captured and logged rather than discarded

**Dockerfile** — yt-dlp moves to `/opt/yt-dlp`, owned by `$APP_UID`, with a symlink at `/usr/local/bin/yt-dlp` so the command stays on `PATH`. The build-time download stays, so a fresh container is immediately usable instead of waiting for the first update tick.

## Verification

Built the `base` stage and ran as the real runtime user.

**Ownership is right:**

```
user: 1654:1654
-rwxr-xr-x 1 app root 3071553 /opt/yt-dlp/yt-dlp
writable by me: YES
dir writable:   YES
```

**Update runs as uid 1654:**

```
2026.07.04
Latest version: stable@2026.07.04 from yt-dlp/yt-dlp
yt-dlp is up to date (stable@2026.07.04 from yt-dlp/yt-dlp)
exit=0
```

**The permission problem is real — proven, not assumed.** `--update` alone exits 0 in *both* layouts, because when yt-dlp is already current it never attempts a write. Forcing an actual binary replacement separates them:

`main`'s layout (root-owned `/usr/local/bin`), running as uid 1654:

```
Updating to stable@2026.06.30 from yt-dlp/yt-dlp ...
ERROR: Unable to write to /usr/local/bin/ytdlp-rootowned; try running as administrator
```

This branch's layout, same command, same user:

```
Updating to stable@2026.06.30 from yt-dlp/yt-dlp ...
ERROR: The requested tag yt-dlp/yt-dlp@2026.06.30 does not exist
```

It gets past the permission stage entirely and only fails on the version tag, which I invented to force the write path. Permissions are no longer the blocker.

`dotnet build` succeeds.

## Judgement calls worth reviewing

- **12 hours** for the interval — frequent enough to pick up extractor fixes within a day, infrequent enough not to hammer GitHub. Easy to change.
- **Update on startup** means a restart always gets the newest version, at the cost of a few seconds of background work during boot. It does not block startup.
- The service updates the binary but running downloads keep using the already-loaded executable; the new version takes effect for subsequent invocations. That seemed preferable to restarting anything mid-request.
