### PR TITLE
fix: stamp the version into assemblies built inside the image

### DIFF
--- a/src/ArgonFetch.API/Dockerfile
+++ b/src/ArgonFetch.API/Dockerfile
@@ -31,8 +31,12 @@ EXPOSE 8080 8081
 # Stage 2: Backend dependencies restore
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS backend-deps
 WORKDIR /src
-# Copy version properties file
-COPY application.properties /application.properties
+# Directory.Build.props stamps the version from application.properties into every
+# assembly. MSBuild finds it by walking up from each project, so both files have to sit
+# above the projects inside the image - copying application.properties to / (as this
+# previously did) put it somewhere nothing reads, and left every assembly on the SDK
+# default 1.0.0.
+COPY Directory.Build.props application.properties ./
 # Copy all csproj files for better caching
 COPY ["src/ArgonFetch.API/ArgonFetch.API.csproj", "src/ArgonFetch.API/"]
 COPY ["src/ArgonFetch.Application/ArgonFetch.Application.csproj", "src/ArgonFetch.Application/"]


### PR DESCRIPTION
Closes #155

Follow-up to #117, which fixed this for local builds but not for the image — the case the original bug was actually about.

## Cause

#117 moved version stamping into a root `Directory.Build.props`. The Dockerfile only copies the `src` directory:

```dockerfile
WORKDIR /src
COPY application.properties /application.properties   # lands at /, nothing reads it
...
COPY ./src .                                          # no Directory.Build.props
```

So MSBuild never saw the props file when walking up from `/src/ArgonFetch.API`, the version property was never set, and every assembly fell back to the SDK default `1.0.0`. `ApplicationInfoService` then read `1.0.0` — wrong in a new way rather than fixed.

The `COPY application.properties /application.properties` line was also stale: it put the file at the root of an intermediate build stage where nothing reads it.

## Change

```diff
-COPY application.properties /application.properties
+COPY Directory.Build.props application.properties ./
```

With `WORKDIR /src`, both land above the projects, so MSBuild finds them from every project directory, and `$(MSBuildThisFileDirectory)application.properties` resolves.

## Verification

Built the **full image** and read the versions out of the shipped assemblies — not a local build, which is exactly the mistake that let this through the first time.

Before:

```
ProductVersion: 1.0.0
```

After:

```
API              0.1.1
Infrastructure   0.1.1
Application      0.1.1
Domain           0.1.1
```

And the value `ApplicationInfoService` actually reads from the shipped `ArgonFetch.Infrastructure.dll`:

```
InformationalVersion: 0.1.1
GetVersion() -> 0.1.1
footer will show  -> v0.1.1
```