### PR TITLE
Bump the version in application.properties, not the csproj files

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -39,10 +39,18 @@ jobs:
       - name: Install semver
         run: bun install -g semver
 
-      - name: Get current version from csproj
+      - name: Get current version
         id: current_version
         run: |
-          CURRENT_VERSION=$(grep -oP '<Version>\K[^<]+' src/ArgonFetch.API/ArgonFetch.API.csproj)
+          # application.properties is the single source of truth; Directory.Build.props
+          # stamps it into every assembly at build time.
+          CURRENT_VERSION=$(grep -oP '<version>\K[^<]+' application.properties)
+
+          if [ -z "$CURRENT_VERSION" ]; then
+            echo "::error::Could not read <version> from application.properties"
+            exit 1
+          fi
+
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           echo "Current version: $CURRENT_VERSION"
 
@@ -59,20 +67,23 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
 
-      - name: Update project version
+      - name: Update version
         run: |
           NEW_VERSION="${{ steps.new_version.outputs.NEW_VERSION }}"
           echo "Updating version to: $NEW_VERSION"
 
-          # Update all .csproj files with Version tag
-          find src -name "*.csproj" -type f -exec sed -i "s/<Version>.*<\/Version>/<Version>$NEW_VERSION<\/Version>/g" {} \;
+          sed -i "s|<version>.*</version>|<version>$NEW_VERSION</version>|" application.properties
 
-          echo "Updated project files:"
-          grep -h "<Version>" src/**/*.csproj || true
+          if ! grep -q "<version>$NEW_VERSION</version>" application.properties; then
+            echo "::error::Failed to write version $NEW_VERSION to application.properties"
+            exit 1
+          fi
+
+          cat application.properties
 
       - name: Commit version bump
         run: |
           NEW_VERSION="${{ steps.new_version.outputs.NEW_VERSION }}"
-          git add src/**/*.csproj
+          git add application.properties
           git commit -m "Bump version to $NEW_VERSION [skip ci]"
           git push origin HEAD:main


### PR DESCRIPTION
Closes #159

## Problem

The workflow read the current version with:

```bash
CURRENT_VERSION=$(grep -oP '<Version>\K[^<]+' src/ArgonFetch.API/ArgonFetch.API.csproj)
```

There is no literal `<Version>` element in that file and there never was — it was an MSBuild property set by an `XmlPeek` target, and since #117 it comes from `Directory.Build.props`. The grep returns an empty string, so:

- `semver -i $BUMP_TYPE ""` gets nothing
- the write-back `sed` matches nothing, changing no files
- `git commit` runs with nothing staged and exits non-zero

The workflow could not have bumped anything. And `application.properties` — the actual source of truth — was never touched, so even a successful run would not have changed the reported version.

## Change

Read and write `application.properties`. Both steps now fail loudly instead of continuing with an empty value.

## Verification

Ran the read → bump → write cycle for each bump type against the real file:

```
start: <?xml version="1.0" encoding="UTF-8"?><properties>    <version>0.1.1</version></properties>

patch: 0.1.1 -> 0.1.2  (write verified)
minor: 0.1.1 -> 0.2.0  (write verified)
major: 0.1.1 -> 1.0.0  (write verified)
```

Worth noting: the XML declaration also contains the word `version` (`<?xml version="1.0" ...?>`). The element-form pattern `<version>` does not match it — the reads returned `0.1.1`, not `1.0`, and the declaration survives the `sed` intact.

File restored to `0.1.1` after testing; the only change in this PR is the workflow.