### PR TITLE
Document the frontend build command that exists

### DIFF
--- a/devenv.md
+++ b/devenv.md
@@ -147,7 +147,7 @@ dotnet publish -c Release -o ./publish
 
 # Build frontend
 cd src/ArgonFetch.Frontend
-bun run build:prod
+bun run build
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Closes #161

`devenv.md` told readers to run `bun run build:prod` for the production frontend build. There is no such script — `package.json` defines `ng`, `start`, `build`, `watch`, `test`, `build:agent` and `apigen` — so the command failed outright.

`build` is the correct one: `angular.json` sets `defaultConfiguration: production` for the build target, so it already produces a production bundle.

## Verification

```
$ bun run build
Application bundle generation complete. [4.044 seconds]
Output location: .../dist/argon-fetch.frontend2
```

(The bundle-budget warning is pre-existing, from the Angular 22 upgrade in #128.)