### PR TITLE
Mount the Postgres volume at the path 18 expects

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "3941:5432"
     volumes:
-      - postgres-data-dev:/var/lib/postgresql/data
+      - postgres-data-dev:/var/lib/postgresql
  
 volumes:
   postgres-data-dev:

--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: argonfetch-db
     env_file: .env
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     ports:
       - "5439:5432"
     restart: unless-stopped


### PR DESCRIPTION
Closes #163

Regression from #149.

## Problem

#149 bumped the image 15 -> 18 but left the mount at `/var/lib/postgresql/data`. Postgres 18 stores data in a major-version-specific subdirectory and expects the volume one level up, so the container crash-looped:

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" ...
       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)
```

`argonfetch-db` restarted 7 times and `/api/App` never responded. This hit **fresh installs too** — reproduced after `docker compose down -v`.

## Why #149 did not catch it

I verified migrations against a `docker run` Postgres 18 container with **no volume mount**, so the default data directory was used and nothing conflicted. That proved EF Core 10 talks to Postgres 18; it proved nothing about the compose setup people actually run. Testing the real thing was the only way to see this.

## Change

```diff
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
```

Same in `compose.dev.yml`.

## Verification

`docker compose down -v && docker compose up -d` on a clean volume:

```
API up after 5s
$ curl http://localhost:4358/api/App
{"version":"v0.1.1","isHealthy":true,"environment":"Production"}

$ docker inspect -f "{{.State.Status}} restarts={{.RestartCount}}" argonfetch-db
running restarts=0
```

Migrations applied, database reachable, app serving. Also the first live confirmation that the version fix works end to end — `v0.1.1`, not `unknown`.

## Note for existing deployments

The upgrade caveat from #149 still stands and is now sharper: an existing `postgres_data` volume holds a 15 data directory at the old path. After this change the mount moves, so a running instance needs a dump/restore. Worth putting in the release notes.