### PR TITLE
Bump the version as the first step of a release

### DIFF
--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -9,12 +9,54 @@ jobs:
     name: Build and Push Multi-Arch Docker Images
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
+      # Check out the default branch rather than the tag: the bump below is committed
+      # back, and the image must be built from the bumped state.
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # The version bump is the first thing a release does. Previously it lived in a
+      # separate, manually dispatched workflow, so a release built whatever
+      # application.properties happened to say and shipped the previous version.
+      - name: Bump version to the release tag
+        id: version
+        run: |
+          RAW_TAG="${{ github.event.release.tag_name }}"
+          VERSION="${RAW_TAG#v}"
+
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Release tag '$RAW_TAG' is not a semantic version"
+            exit 1
+          fi
+
+          sed -i "s|<version>.*</version>|<version>$VERSION</version>|" application.properties
+
+          if ! grep -q "<version>$VERSION</version>" application.properties; then
+            echo "::error::Failed to write version $VERSION to application.properties"
+            exit 1
+          fi
+
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          cat application.properties
+
+      - name: Commit version bump
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+
+          if git diff --quiet application.properties; then
+            echo "application.properties already at ${{ steps.version.outputs.VERSION }}; nothing to commit"
+          else
+            git add application.properties
+            git commit -m "Bump version to ${{ steps.version.outputs.VERSION }} [skip ci]"
+            git push origin HEAD:${{ github.event.repository.default_branch }}
+          fi
 
       - name: Prepare repository name
         id: prep


### PR DESCRIPTION
Closes #168

## Problem

Publishing a release shipped an image reporting the **previous** version.

`docker-publish-release.yaml` triggers on `release: published` and builds from the checked-out commit. The reported version comes from `application.properties`, which was only ever changed by the separate, manually dispatched Version Bump workflow — nothing in the release path touched it. So every release built whatever the file already said.

## Change

The bump is now the first thing a release does:

1. Check out the default branch (not the tag) — the bump is committed back and the image must build from the bumped state
2. Derive the version from `release.tag_name`, stripping a leading `v`
3. **Validate it is semver** and fail the run otherwise
4. Write it to `application.properties`, verify the write
5. Commit and push to the default branch
6. Build and publish from that state

`contents` permission goes from `read` to `write` for the push.

## Verification

YAML parses. Bump logic exercised against the real file:

```
tag parsed -> 0.2.0
write verified: <version>0.2.0</version>
```

Tag validation:

```
"latest"      rejected
"v1.2"        rejected
"1.2.3-beta"  rejected
```

File restored afterwards; the only change here is the workflow.

## Note

This overlaps the standalone Version Bump workflow (fixed in #160), which stays useful for bumping *without* releasing. A release no longer depends on anyone remembering to run it.