### PR TITLE
Submit the URL form when Enter is pressed

### DIFF
--- a/src/ArgonFetch.Frontend/src/app/home/home.component.html
+++ b/src/ArgonFetch.Frontend/src/app/home/home.component.html
@@ -6,21 +6,21 @@
     <h1>ArgonFetch</h1>
     <p class="subtitle">Universal Media Downloader</p>
 
-    <div class="download-box">
+    <form class="download-box" (ngSubmit)="download()">
       <div class="url-input-wrapper">
         <fa-icon [icon]="faLink" class="url-icon"></fa-icon>
-        <input type="text" placeholder="Enter URL to download..." [(ngModel)]="url">
+        <input type="text" name="url" placeholder="Enter URL to download..." [(ngModel)]="url">
         @if (url) {
-          <button class="clear-btn" (click)="url = ''" aria-label="Clear input">
+          <button type="button" class="clear-btn" (click)="url = ''" aria-label="Clear input">
             <fa-icon [icon]="faTimes"></fa-icon>
           </button>
         }
       </div>
-      <button class="search-btn" (click)="download()" [disabled]="isLoading">
+      <button type="submit" class="search-btn" [disabled]="isLoading">
         <fa-icon [icon]="faSearch"></fa-icon>
         {{ isLoading ? 'Searching...' : 'Search' }}
       </button>
-    </div>
+    </form>
 
     <!-- Skeleton Loader -->
     @if (isLoading) {

--- a/src/ArgonFetch.Frontend/src/app/home/home.component.ts
+++ b/src/ArgonFetch.Frontend/src/app/home/home.component.ts
@@ -47,6 +47,12 @@ export class HomeComponent {
   ) { }
 
   async download() {
+    // Enter can fire while a fetch is already running; the Search button is disabled
+    // for the same reason.
+    if (this.isLoading) {
+      return;
+    }
+
     if (!this.url) {
       this.modalService.open({
         title: 'Yoooo! No URL Detected',


### PR DESCRIPTION
Closes #167

The URL input bound only `ngModel` — no key handler, no enclosing form — so Enter did nothing and the Search button was the only way to fetch.

## Change

Wrap the input and button in a `<form (ngSubmit)="download()">` with `type="submit"` on the Search button. The clear button is explicitly `type="button"` so it does not submit. `download()` returns early while a fetch is in flight, which is what the button `disabled` state already expressed.

## Verification

Against the running stack: typing a Spotify URL and pressing Enter fires `GET /api/Fetch/GetResource` and renders "Never Gonna Give You Up" / "Rick Astley" with cover art.

## Worth recording: my first three attempts "failed" for a bogus reason

I reported this unfixable after three approaches. That was wrong — Playwright was serving a **cached `index.html`**, so every test ran against `main-WJA66BES.js`, the bundle from before any of my changes, while the container was serving `main-LHURTW4W.js`. The fixes were never actually exercised.

What exposed it: querying the DOM for `form.download-box` returned `false` even though the deployed bundle contained `ngSubmit` six times. Checking `document.querySelectorAll("script[src]")` showed the stale bundle name.

Two lessons for future frontend testing here: grep the served bundle for a string **unique to your own change** (my earlier `grep -c "keyup.enter"` matched Angular framework code and counted lines in minified JS, so it was meaningless either way), and confirm which bundle the page actually loaded before concluding anything.

`ChangeDetectionStrategy.Eager` was also investigated and ruled out — it is what the v22 `ng update` migration writes and is an alias for the old `Default`.