### PR TITLE
Declare Content-Length when the media stream is passed through unchanged

### DIFF
--- a/src/ArgonFetch.Application/Interfaces/IAcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Application/Interfaces/IAcceleratedDownloadService.cs
@@ -11,5 +11,13 @@ namespace ArgonFetch.Application.Interfaces
             Stream outputStream,
             IProgress<double>? progress = null,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Length the upstream reports for the resource, or null when it does not report one.
+        /// Callers use it to declare Content-Length on a pass-through response.
+        /// </summary>
+        Task<long?> GetContentLengthAsync(
+            string url,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
@@ -97,8 +97,26 @@ namespace ArgonFetch.Application.Queries
                     // Add cache headers
                     request.Response.Headers.Append("Cache-Control", "public, max-age=3600");
 
-                    // Note: We don't set Content-Length as we might be chunking
-                    // The accelerated download will handle range requests if supported
+                    // This path copies the upstream bytes through unchanged, so the upstream
+                    // length is the response length and can be declared. Without it the client
+                    // gets no Content-Length and cannot show real download progress.
+                    //
+                    // Only declared when the probe returns a length: whatever is written must
+                    // match it exactly or Kestrel throws on response completion. Conversion is
+                    // handled in the branch above, where the output length is not knowable.
+                    var upstreamLength = await _acceleratedDownloadService.GetContentLengthAsync(
+                        mediaUrl,
+                        request.CancellationToken);
+
+                    if (upstreamLength.HasValue)
+                    {
+                        request.Response.ContentLength = upstreamLength.Value;
+                        _logger.LogInformation("Declared Content-Length {Length} for {Url}", upstreamLength.Value, mediaUrl);
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Upstream did not report a length for {Url}; response will be chunked", mediaUrl);
+                    }
 
                     // The service already falls back to a single connection internally, and only
                     // while doing so is still safe. Retrying here would append a second copy of

--- a/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
@@ -34,6 +34,41 @@ namespace ArgonFetch.Infrastructure.Services
             return memoryStream;
         }
 
+        /// <summary>
+        /// Length the upstream reports, or null when it does not report one. A failure here is
+        /// not fatal - the caller simply cannot declare Content-Length and the response is chunked.
+        /// </summary>
+        public async Task<long?> GetContentLengthAsync(
+            string url,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var httpClient = _httpClientFactory.CreateClient(MediaHttpClientDefaults.ClientName);
+
+                using var headRequest = new HttpRequestMessage(HttpMethod.Head, url);
+                using var headResponse = await httpClient.SendAsync(headRequest, cancellationToken);
+
+                if (!headResponse.IsSuccessStatusCode)
+                {
+                    _logger.LogWarning("HEAD request returned {StatusCode}; cannot determine content length",
+                        (int)headResponse.StatusCode);
+                    return null;
+                }
+
+                return headResponse.Content.Headers.ContentLength;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not determine content length for {Url}", url);
+                return null;
+            }
+        }
+
         public async Task StreamWithAccelerationAsync(
             string url,
             Stream outputStream,


### PR DESCRIPTION
Closes #173

Follow-up to #174, which made the progress bar honest but left it always indeterminate because nothing declares a length.

## Change

On the pass-through branch the upstream bytes are copied through unaltered, so the upstream length is the response length. Declare it when the HEAD probe reports one.

Only on that branch — whatever is written must match the declared length exactly or Kestrel throws on response completion. The conversion branch muxes on the fly and keeps chunking.

`GetContentLengthAsync` is added to `IAcceleratedDownloadService` and implemented; it previously existed only on the #116 branch.

## Verification, and an honest limit

`dotnet build` succeeds. Against the running stack the change is a **no-op for the case I could test**, and that is worth stating plainly rather than claiming a win:

```
GET /api/Stream/Media/{key}   ->  HTTP 200, Transfer-Encoding: chunked
log: Converting media from https://rr3---sn-....googlevideo.com/videoplayback?...&mime=audio%2Fmp4 to MP3
```

The download completed correctly (5127243 bytes, valid MPEG layer III), but it took the **conversion** path, so no length is declarable and chunked is right.

That exposes something the issue understated: `IsStandardFormat` inspects the **upstream URL extension**, and YouTube/Spotify media resolves to `googlevideo.com/videoplayback?...` URLs with no extension. So essentially every download converts, and the pass-through branch this PR improves is rarely taken in practice.

So this is correct and safe, but on its own it will not make the progress bar determinate for real usage. Getting there means either declaring a length for the conversion path (not knowable up front) or reconsidering how `IsStandardFormat` decides — `mime=audio/mp4` is right there in the query string, and #82 already covered reading content type rather than guessing from the extension. Worth a separate issue; I did not want to widen this one.