### PR TITLE
Detect source format from its media type, not the URL extension

### DIFF
--- a/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
@@ -153,19 +153,55 @@ namespace ArgonFetch.Application.Queries
             }
         }
 
+        /// <summary>
+        /// Whether the source can be served untouched.
+        /// <para>
+        /// ProxyUrlBuilder promises ".mp3" for audio and ".mp4" for video, so audio still
+        /// converts unless the source really is MP3. Video that is already MP4 does not need
+        /// re-encoding, but that was never detected: this looked at the URL's file extension
+        /// and real media URLs (googlevideo videoplayback?...) have none, so every video was
+        /// re-encoded with libx264 to produce another MP4.
+        /// </para>
+        /// </summary>
         private bool IsStandardFormat(string url, bool isAudio)
         {
-            var extension = GetFileExtension(url);
+            var mimeType = GetMimeType(url);
 
             if (isAudio)
             {
-                // Only MP3 is considered standard for audio
-                return extension.Equals(".mp3", StringComparison.OrdinalIgnoreCase);
+                // The delivered file is advertised as MP3, so anything else has to be converted.
+                return mimeType is "audio/mpeg" or "audio/mp3"
+                    || GetFileExtension(url).Equals(".mp3", StringComparison.OrdinalIgnoreCase);
             }
-            else
+
+            return mimeType == "video/mp4"
+                || GetFileExtension(url).Equals(".mp4", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// The source's media type. Media URLs carry it as a "mime" query parameter
+        /// (e.g. mime=video%2Fmp4) even though the path has no file extension.
+        /// </summary>
+        private string? GetMimeType(string url)
+        {
+            try
             {
-                // Only MP4 is considered standard for video
-                return extension.Equals(".mp4", StringComparison.OrdinalIgnoreCase);
+                var query = new Uri(url).Query;
+
+                if (string.IsNullOrEmpty(query))
+                {
+                    return null;
+                }
+
+                var mime = Microsoft.AspNetCore.WebUtilities.QueryHelpers
+                    .ParseQuery(query)
+                    .TryGetValue("mime", out var values) ? values.ToString() : null;
+
+                return string.IsNullOrWhiteSpace(mime) ? null : mime.Trim().ToLowerInvariant();
+            }
+            catch
+            {
+                return null;
             }
         }
 


### PR DESCRIPTION
Closes #176

## Problem

`IsStandardFormat` decided whether to transcode by reading the file extension from the upstream URL. Real media URLs have none:

```
https://rr5---sn-....googlevideo.com/videoplayback?expire=...&mime=video%2Fmp4&...
```

So the check always failed and video was re-encoded with `libx264 -preset ultrafast -crf 23` into another MP4 — CPU cost and a generation of quality loss for a source that was already in the target format.

## Change

Read the `mime` query parameter these URLs carry, falling back to the extension.

**Audio still converts.** I initially wrote this up as waste on every download; that was wrong. `ProxyUrlBuilder` deliberately standardizes the delivered extension to `.mp3` for audio, and YouTube audio sources are `audio/mp4`/`audio/webm`, so transcoding is required to honour that promise. Only video gains the pass-through.

## Verification

Regression-tested the audio path against the running stack — still converts, still correct:

```
HTTP/1.1 200 OK, Transfer-Encoding: chunked
log: Converting media from https://rr5---sn-....googlevideo.com/videoplayback?... to MP3
5115331 bytes, "MPEG ADTS, layer III, v1, 192 kbps, 44.1 kHz"
```

**Not exercised:** the video pass-through itself. The test video has no pre-muxed format, so its video reference comes back as `urlType=Combined` and goes to the FFmpeg muxing endpoint rather than this branch. The branch is reached only when yt-dlp finds a pre-muxed MP4. Worth confirming on such a video before relying on it.

`dotnet build` clean.