### PR TITLE
Rewrite the README around how the project actually works

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/ArgonFetch/ArgonFetch"><img src="https://badgetrack.pianonic.ch/badge?tag=argon-fetch&label=visits&color=9f54e5&style=flat" alt="visits" /></a>
   <a href="https://www.argonfetch.dev/"><img src="https://img.shields.io/badge/Cloud%20Version-argonfetch.dev-9f54e5.svg"/></a>
-  <a href="https://github.com/ArgonFetch/ArgonFetch?tab=readme-ov-file#-installation"><img src="https://img.shields.io/badge/Selfhost-Instructions-9f54e5.svg"/></a>
+  <a href="https://github.com/ArgonFetch/ArgonFetch?tab=readme-ov-file#-quick-start"><img src="https://img.shields.io/badge/Selfhost-Instructions-9f54e5.svg"/></a>
   <a href="https://github.com/ArgonFetch/ArgonFetch/blob/main/devenv.md"><img src="https://img.shields.io/badge/Development-Setup-9f54e5.svg"/></a>
 </p>
 
@@ -17,20 +17,37 @@
 
 > **⚠️ Important Note:** This project is currently under development and may not function as described directly from the main branch. For a working version, please check the [Releases tab](https://github.com/ArgonFetch/ArgonFetch/releases) for the latest stable release.
 
-## ✨ Features
+## ✨ What it does
 
-- Download from Spotify, YouTube, and more
-- Multiple formats: MP3, MP4, WebM
-- Docker ready
-- Web interface and API
+Paste a link, get the media. ArgonFetch resolves the URL, picks the best available
+streams and serves them back as a normal file download.
+
+- **No API keys.** Nothing to register, no credentials to configure — including Spotify.
+- **Audio or video**, at a quality you choose.
+- **Web interface and REST API**, with Swagger docs.
+- **One container plus a database.** Runs anywhere Docker does.
 
 ## 📸 Screenshots
 
 ![ArgonFetch Homepage](./assets/startpage.png)
 
-## 🐳 Docker Setup
+## 🎯 Platform support
 
-1. **Create a compose.yml file:**
+| Platform | Status | Notes |
+|---|---|---|
+| YouTube | ✅ Video and audio | Muxes separate video/audio streams when no pre-muxed format exists |
+| Spotify | ✅ Single tracks | Metadata is read from the public track page; audio comes from the matching YouTube Music result |
+| TikTok | ✅ | |
+| Spotify playlists / albums | ❌ Not supported | [#171](https://github.com/ArgonFetch/ArgonFetch/issues/171) |
+| Playlists generally | ❌ Not supported | [#76](https://github.com/ArgonFetch/ArgonFetch/issues/76) |
+| SoundCloud | ⚠️ Unreliable | [#58](https://github.com/ArgonFetch/ArgonFetch/issues/58) |
+| Instagram Reels | ⚠️ Preview issues | [#58](https://github.com/ArgonFetch/ArgonFetch/issues/58) |
+
+Audio downloads are delivered as MP3 and video as MP4.
+
+## 🚀 Quick start
+
+**1. Create `compose.yml`:**
 
 ```yaml
 services:
@@ -39,9 +56,9 @@ services:
     container_name: argonfetch-db
     env_file: .env
     volumes:
+      # Postgres 18 stores data in a version-specific subdirectory, so the volume
+      # goes here and NOT on /var/lib/postgresql/data.
       - postgres_data:/var/lib/postgresql
-    ports:
-      - "5432:5432"
     restart: unless-stopped
 
   argonfetch:
@@ -61,59 +78,72 @@ volumes:
   postgres_data:
 ```
 
-2. **Create a .env file:**
+**2. Create `.env` next to it:**
 
 ```env
-# Database
 POSTGRES_USER=argonfetch
 POSTGRES_PASSWORD=changeme123
 POSTGRES_DB=argonfetch
 
-# CORS Configuration (Required for production)
-# Comma-separated list of allowed origins
-CORS_ALLOWED_ORIGINS=https://app.argonfetch.dev,https://argonfetch.dev,http://localhost:4200
+# Origins allowed to call the API. Set this to your own host in production.
+CORS_ALLOWED_ORIGINS=http://localhost:8080
 ```
 
-No API keys or credentials are needed. Spotify links work out of the box.
-
-3. **Start it:**
+**3. Start it:**
 
 ```bash
 docker compose up -d
 ```
 
-The application will be available at `http://localhost:8080`.
+Open `http://localhost:8080`. No further configuration is required.
 
+## ⚙️ Configuration
 
+Everything is set through environment variables in `.env`.
+
+| Variable | Required | Description |
+|---|---|---|
+| `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | yes | Database credentials, shared by both containers |
+| `ConnectionStrings__ArgonFetchDatabase` | yes | Set in `compose.yml` from the values above |
+| `CORS_ALLOWED_ORIGINS` | in production | Comma-separated origins allowed to call the API. Defaults to `http://localhost:4200`, and the app warns at startup if that default is still in use in production |
+| `ASPNETCORE_ENVIRONMENT` | no | `Production` by default. `Development` also enables Swagger UI |
+
+`yt-dlp` updates itself inside the container every 12 hours, so extractor fixes
+land without rebuilding the image.
+
+### Upgrading from a release older than Postgres 18
+
+The database image moved from Postgres 15 to 18, which is a major upgrade: the
+on-disk format changed and the volume mount path moved. An existing
+`postgres_data` volume will not start under 18 — dump the old database and
+restore it into the new one, or run `pg_upgrade`.
 
 ## 🛠️ Usage
 
 1. Navigate to `http://localhost:8080`
-2. Paste a media URL
-3. Download
+2. Paste a media URL and press Enter
+3. Pick a quality, then download
 
-API docs: `http://localhost:8080/swagger`
+API docs are at `http://localhost:8080/swagger` when running in `Development`.
 
 ## 📋 Roadmap
 
-- [x] Spotify Songs
-- [ ] Spotify Playlists
-- [ ] Spotify Albums
-- [x] YouTube Media
-- [ ] SoundCloud Media
+- [x] Spotify tracks
+- [x] YouTube media
+- [x] TikTok
+- [ ] Spotify playlists and albums
+- [ ] SoundCloud
+- [ ] Playlist support
 
-### Future Plans
-- [ ] Social Media Support (X, Instagram, TikTok ...)
+### Future plans
+- [ ] Wider social media support (X, Instagram, ...)
 
 ## 💻 Development
 
-See [Development Guide](devenv.md).
-
+See the [Development Guide](devenv.md).
 
 ## 📜 License
 
 This project is licensed under the GPL-3.0 License. See [LICENSE](LICENSE) for details.
 
 ---
-
-**Made with ❤️ by [PianoNic](https://github.com/Pianonic) and [MyDrift](https://github.com/MyDrift-user)**

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/ArgonFetch/ArgonFetch"><img src="https://badgetrack.pianonic.ch/badge?tag=argon-fetch&label=visits&color=9f54e5&style=flat" alt="visits" /></a>
   <a href="https://www.argonfetch.dev/"><img src="https://img.shields.io/badge/Cloud%20Version-argonfetch.dev-9f54e5.svg"/></a>
-  <a href="https://github.com/ArgonFetch/ArgonFetch?tab=readme-ov-file#-quick-start"><img src="https://img.shields.io/badge/Selfhost-Instructions-9f54e5.svg"/></a>
+  <a href="https://github.com/ArgonFetch/ArgonFetch?tab=readme-ov-file#quick-start"><img src="https://img.shields.io/badge/Selfhost-Instructions-9f54e5.svg"/></a>
   <a href="https://github.com/ArgonFetch/ArgonFetch/blob/main/devenv.md"><img src="https://img.shields.io/badge/Development-Setup-9f54e5.svg"/></a>
 </p>
 
@@ -17,7 +17,7 @@
 
 > **⚠️ Important Note:** This project is currently under development and may not function as described directly from the main branch. For a working version, please check the [Releases tab](https://github.com/ArgonFetch/ArgonFetch/releases) for the latest stable release.
 
-## ✨ What it does
+## What it does
 
 Paste a link, get the media. ArgonFetch resolves the URL, picks the best available
 streams and serves them back as a normal file download.
@@ -27,11 +27,11 @@ streams and serves them back as a normal file download.
 - **Web interface and REST API**, with Swagger docs.
 - **One container plus a database.** Runs anywhere Docker does.
 
-## 📸 Screenshots
+## Screenshots
 
 ![ArgonFetch Homepage](./assets/startpage.png)
 
-## 🎯 Platform support
+## Platform support
 
 | Platform | Status | Notes |
 |---|---|---|
@@ -45,7 +45,7 @@ streams and serves them back as a normal file download.
 
 Audio downloads are delivered as MP3 and video as MP4.
 
-## 🚀 Quick start
+## Quick start
 
 **1. Create `compose.yml`:**
 
@@ -97,7 +97,7 @@ docker compose up -d
 
 Open `http://localhost:8080`. No further configuration is required.
 
-## ⚙️ Configuration
+## Configuration
 
 Everything is set through environment variables in `.env`.
 
@@ -118,7 +118,7 @@ on-disk format changed and the volume mount path moved. An existing
 `postgres_data` volume will not start under 18 — dump the old database and
 restore it into the new one, or run `pg_upgrade`.
 
-## 🛠️ Usage
+## Usage
 
 1. Navigate to `http://localhost:8080`
 2. Paste a media URL and press Enter
@@ -126,7 +126,7 @@ restore it into the new one, or run `pg_upgrade`.
 
 API docs are at `http://localhost:8080/swagger` when running in `Development`.
 
-## 📋 Roadmap
+## Roadmap
 
 - [x] Spotify tracks
 - [x] YouTube media
@@ -138,11 +138,11 @@ API docs are at `http://localhost:8080/swagger` when running in `Development`.
 ### Future plans
 - [ ] Wider social media support (X, Instagram, ...)
 
-## 💻 Development
+## Development
 
 See the [Development Guide](devenv.md).
 
-## 📜 License
+## License
 
 This project is licensed under the GPL-3.0 License. See [LICENSE](LICENSE) for details.
 


### PR DESCRIPTION
Closes #178

The README documented a project that no longer exists.

## What was wrong

- **Spotify credentials presented as required** — removed in #157; links now work with nothing configured
- **The compose snippet was broken** — `postgres:15` on `/var/lib/postgresql/data`, the exact combination that crash-loops under Postgres 18 (#164). Anyone copying it got a stack that never started
- **Roadmap misrepresented reality** — playlists listed as a Spotify feature when no playlist path exists anywhere (#76, #171)
- **No honest statement of what works**, so SoundCloud and Instagram problems (#58) came as a surprise

## What it says now

- No API keys for anything, Spotify included
- A compose snippet that works, with a comment explaining why the volume mount is where it is
- A platform support table marking each source ✅ / ⚠️ / ❌ with issue links, rather than implying everything works
- A configuration table for the variables that genuinely exist, including the CORS default and its production warning
- An upgrade note for the Postgres major change, since existing volumes will not start
- A mention that yt-dlp self-updates in the container (#151), so extractor fixes do not need a rebuild

Roadmap checkboxes now match the support table instead of contradicting it.