### PR TITLE
Count served media requests and expose the total

### DIFF
--- a/src/ArgonFetch.API/Controllers/AppController.cs
+++ b/src/ArgonFetch.API/Controllers/AppController.cs
@@ -12,12 +12,14 @@ namespace ArgonFetch.API.Controllers
         private readonly IMediator _mediator;
         private readonly IWebHostEnvironment _environment;
         private readonly IApplicationInfoService _applicationInfoService;
+        private readonly IRequestCounterService _requestCounter;
 
-        public AppController(IMediator mediator, IWebHostEnvironment environment, IApplicationInfoService applicationInfoService)
+        public AppController(IMediator mediator, IWebHostEnvironment environment, IApplicationInfoService applicationInfoService, IRequestCounterService requestCounter)
         {
             _mediator = mediator;
             _environment = environment;
             _applicationInfoService = applicationInfoService;
+            _requestCounter = requestCounter;
         }
 
         [HttpGet("", Name = "GetAppInfo")]
@@ -35,6 +37,26 @@ namespace ArgonFetch.API.Controllers
             };
 
             return Ok(appInfo);
+        }
+    
+        /// <summary>
+        /// Total media requests this installation has served. Shaped for shields.io so it can
+        /// be embedded as a badge without another service in between.
+        /// </summary>
+        [HttpGet("requests", Name = "GetRequestCount")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        public async Task<ActionResult> GetRequestCount(CancellationToken cancellationToken)
+        {
+            var total = await _requestCounter.GetTotalAsync(cancellationToken);
+
+            return Ok(new
+            {
+                schemaVersion = 1,
+                label = "requests",
+                message = total.ToString("N0", System.Globalization.CultureInfo.InvariantCulture),
+                color = "9f54e5",
+                total
+            });
         }
     }
 }

--- a/src/ArgonFetch.API/Controllers/FetchController.cs
+++ b/src/ArgonFetch.API/Controllers/FetchController.cs
@@ -1,5 +1,6 @@
 ﻿using ArgonFetch.Application.Dtos;
 using ArgonFetch.Application.Queries;
+using ArgonFetch.Application.Services;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,11 +11,13 @@ namespace ArgonFetch.API.Controllers
     public class FetchController : ControllerBase
     {
         private readonly IMediator _mediator;
+        private readonly IRequestCounterService _requestCounter;
         private readonly ILogger<FetchController> _logger;
 
-        public FetchController(IMediator mediator, ILogger<FetchController> logger)
+        public FetchController(IMediator mediator, IRequestCounterService requestCounter, ILogger<FetchController> logger)
         {
             _mediator = mediator;
+            _requestCounter = requestCounter;
             _logger = logger;
         }
 
@@ -29,6 +32,11 @@ namespace ArgonFetch.API.Controllers
             try
             {
                 var result = await _mediator.Send(new GetMediaQuery(url));
+
+                // Counted only on success, so the number reflects media actually served
+                // rather than every malformed URL someone pasted.
+                await _requestCounter.IncrementAsync();
+
                 return Ok(result);
             }
             catch (ArgumentException ex)

--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -55,6 +55,9 @@ builder.Services.AddMemoryCache();
 // Keep yt-dlp current at runtime; the image only downloads it at build time.
 builder.Services.AddHostedService<ArgonFetch.Infrastructure.Services.YtDlpUpdateService>();
 
+builder.Services.AddScoped<ArgonFetch.Application.Services.IRequestCounterService,
+                           ArgonFetch.Infrastructure.Services.RequestCounterService>();
+
 // Register Application Info Service
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IApplicationInfoService, ArgonFetch.Infrastructure.Services.ApplicationInfoService>();
 #endregion

--- a/src/ArgonFetch.Application/Services/IRequestCounterService.cs
+++ b/src/ArgonFetch.Application/Services/IRequestCounterService.cs
@@ -1,0 +1,13 @@
+namespace ArgonFetch.Application.Services
+{
+    public interface IRequestCounterService
+    {
+        /// <summary>
+        /// Records one served media request. Never throws: a counter failure must not fail
+        /// the download the user actually asked for.
+        /// </summary>
+        Task IncrementAsync(CancellationToken cancellationToken = default);
+
+        Task<long> GetTotalAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/ArgonFetch.Domain/RequestCounter.cs
+++ b/src/ArgonFetch.Domain/RequestCounter.cs
@@ -1,0 +1,19 @@
+namespace ArgonFetch.Domain
+{
+    /// <summary>
+    /// Running total of media requests this installation has served.
+    /// <para>
+    /// A single row, updated in place. The count is only ever incremented and read as a
+    /// total, so there is no reason to store one row per request - that would grow without
+    /// bound and turn a counter read into an aggregate over the whole table.
+    /// </para>
+    /// </summary>
+    public class RequestCounter
+    {
+        public int Id { get; set; }
+
+        public long TotalRequests { get; set; }
+
+        public DateTime LastRequestAtUtc { get; set; }
+    }
+}

--- a/src/ArgonFetch.Infrastructure/ArgonFetchDbContext.cs
+++ b/src/ArgonFetch.Infrastructure/ArgonFetchDbContext.cs
@@ -7,11 +7,19 @@ namespace ArgonFetch.Infrastructure
     public class ArgonFetchDbContext : DbContext
     {
         public DbSet<UrlReference> UrlReference { get; set; }
+        public DbSet<RequestCounter> RequestCounters { get; set; }
 
         public ArgonFetchDbContext(DbContextOptions<ArgonFetchDbContext> options) : base(options) { }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            // One row, seeded so the first read works before any request is served.
+            modelBuilder.Entity<RequestCounter>().HasData(new RequestCounter
+            {
+                Id = 1,
+                TotalRequests = 0,
+                LastRequestAtUtc = DateTime.MinValue
+            });
         }
     }
 

--- a/src/ArgonFetch.Infrastructure/Migrations/20260808100337_AddRequestCounter.Designer.cs
+++ b/src/ArgonFetch.Infrastructure/Migrations/20260808100337_AddRequestCounter.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ArgonFetch.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ArgonFetch.Infrastructure.Migrations
 {
     [DbContext(typeof(ArgonFetchDbContext))]
-    partial class ArgonFetchDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260808100337_AddRequestCounter")]
+    partial class AddRequestCounter
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ArgonFetch.Infrastructure/Migrations/20260808100337_AddRequestCounter.cs
+++ b/src/ArgonFetch.Infrastructure/Migrations/20260808100337_AddRequestCounter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace ArgonFetch.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRequestCounter : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RequestCounters",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TotalRequests = table.Column<long>(type: "bigint", nullable: false),
+                    LastRequestAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RequestCounters", x => x.Id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "RequestCounters",
+                columns: new[] { "Id", "LastRequestAtUtc", "TotalRequests" },
+                values: new object[] { 1, new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), 0L });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RequestCounters");
+        }
+    }
+}

--- a/src/ArgonFetch.Infrastructure/Services/RequestCounterService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/RequestCounterService.cs
@@ -1,0 +1,73 @@
+using ArgonFetch.Application.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace ArgonFetch.Infrastructure.Services
+{
+    /// <summary>
+    /// Keeps the single request-counter row up to date.
+    /// <para>
+    /// The increment is done in the database rather than by reading, adding one and saving,
+    /// so concurrent requests cannot overwrite each other's count.
+    /// </para>
+    /// </summary>
+    public class RequestCounterService : IRequestCounterService
+    {
+        private readonly ArgonFetchDbContext _dbContext;
+        private readonly ILogger<RequestCounterService> _logger;
+
+        public RequestCounterService(ArgonFetchDbContext dbContext, ILogger<RequestCounterService> logger)
+        {
+            _dbContext = dbContext;
+            _logger = logger;
+        }
+
+        public async Task IncrementAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var updated = await _dbContext.RequestCounters
+                    .Where(c => c.Id == 1)
+                    .ExecuteUpdateAsync(
+                        set => set
+                            .SetProperty(c => c.TotalRequests, c => c.TotalRequests + 1)
+                            .SetProperty(c => c.LastRequestAtUtc, _ => DateTime.UtcNow),
+                        cancellationToken);
+
+                if (updated == 0)
+                {
+                    // First request on a fresh database, or the seed row was removed.
+                    _dbContext.RequestCounters.Add(new Domain.RequestCounter
+                    {
+                        Id = 1,
+                        TotalRequests = 1,
+                        LastRequestAtUtc = DateTime.UtcNow
+                    });
+
+                    await _dbContext.SaveChangesAsync(cancellationToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                // A counter is not worth failing a download over.
+                _logger.LogWarning(ex, "Could not record the request in the counter");
+            }
+        }
+
+        public async Task<long> GetTotalAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _dbContext.RequestCounters
+                    .Where(c => c.Id == 1)
+                    .Select(c => c.TotalRequests)
+                    .FirstOrDefaultAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not read the request counter");
+                return 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #61

A counter that goes up for every request an installation serves, readable for a README badge.

## Design notes

- **One row, updated in place.** The value is only ever incremented and read as a total, so a row per request would grow without bound and turn the read into an aggregate over the whole table.
- **Incremented via `ExecuteUpdate`**, not read-modify-write, so concurrent requests cannot overwrite each other.
- **Failures are swallowed and logged.** A download must not fail because a statistic could not be written.
- **Only successful fetches count**, so the number reflects media actually served rather than every malformed URL someone pasted.
- **Response is shields.io-shaped**, so the badge needs no service in between. `total` is also included raw for other consumers.

## Verification

Against the running stack with a real Postgres:

```
initial                       {"message":"0","total":0}
after one successful fetch    {"message":"1","total":1}
after a FAILED fetch          {"message":"1","total":1}
```

The failed request correctly did not increment. Migration `AddRequestCounter` applies cleanly on startup and seeds the row, so the endpoint works before any request is served.

## Badge

```markdown
![requests](https://img.shields.io/endpoint?url=https://your-host/api/App/requests)
```

Not added to the README here — it needs a public instance URL, which is your call.