### PR TITLE
Stamp the release version from the tag instead of committing it

### DIFF
--- a/.github/workflows/docker-publish-release.yaml
+++ b/.github/workflows/docker-publish-release.yaml
@@ -9,22 +9,17 @@ jobs:
     name: Build and Push Multi-Arch Docker Images
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
 
     steps:
-      # Check out the default branch rather than the tag: the bump below is committed
-      # back, and the image must be built from the bumped state.
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      # The version bump is the first thing a release does. Previously it lived in a
-      # separate, manually dispatched workflow, so a release built whatever
-      # application.properties happened to say and shipped the previous version.
-      - name: Bump version to the release tag
+      # The published image must report the released version. Deriving it from the tag
+      # and passing it into the build avoids committing anything: main requires signed
+      # commits and pull requests, so a workflow push is rejected outright (#186).
+      - name: Resolve version from the release tag
         id: version
         run: |
           RAW_TAG="${{ github.event.release.tag_name }}"
@@ -35,28 +30,8 @@ jobs:
             exit 1
           fi
 
-          sed -i "s|<version>.*</version>|<version>$VERSION</version>|" application.properties
-
-          if ! grep -q "<version>$VERSION</version>" application.properties; then
-            echo "::error::Failed to write version $VERSION to application.properties"
-            exit 1
-          fi
-
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          cat application.properties
-
-      - name: Commit version bump
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-
-          if git diff --quiet application.properties; then
-            echo "application.properties already at ${{ steps.version.outputs.VERSION }}; nothing to commit"
-          else
-            git add application.properties
-            git commit -m "Bump version to ${{ steps.version.outputs.VERSION }} [skip ci]"
-            git push origin HEAD:${{ github.event.repository.default_branch }}
-          fi
+          echo "Building version $VERSION"
 
       - name: Prepare repository name
         id: prep
@@ -115,5 +90,6 @@ jobs:
           # Build in parallel where possible
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+            APP_VERSION=${{ steps.version.outputs.VERSION }}
           provenance: false
           sbom: false

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,9 +9,11 @@
     <ApplicationPropertiesFile>$(MSBuildThisFileDirectory)application.properties</ApplicationPropertiesFile>
   </PropertyGroup>
 
+  <!-- Skipped when Version is supplied on the command line, which is how a release
+       stamps the tag's version in without committing to the repository. -->
   <Target Name="ReadVersionFromProperties"
           BeforeTargets="GetAssemblyVersion;GenerateAssemblyInfo"
-          Condition="Exists('$(ApplicationPropertiesFile)')">
+          Condition="Exists('$(ApplicationPropertiesFile)') AND '$(Version)' == '1.0.0'">
     <XmlPeek XmlInputPath="$(ApplicationPropertiesFile)" Query="/properties/version/text()">
       <Output TaskParameter="Result" PropertyName="VersionFromProperties" />
     </XmlPeek>

--- a/src/ArgonFetch.API/Dockerfile
+++ b/src/ArgonFetch.API/Dockerfile
@@ -47,12 +47,16 @@ RUN dotnet restore "src/ArgonFetch.API/ArgonFetch.API.csproj"
 # Stage 3: Backend build
 FROM backend-deps AS backend-build
 ARG BUILD_CONFIGURATION=Release
+# Set by the release workflow from the git tag. Empty for local builds, where the
+# version falls back to application.properties.
+ARG APP_VERSION=
 COPY ./src .
 WORKDIR "/src/ArgonFetch.API"
 RUN dotnet publish "ArgonFetch.API.csproj" \
     -c $BUILD_CONFIGURATION \
     -o /app/publish \
-    /p:UseAppHost=false
+    /p:UseAppHost=false \
+    ${APP_VERSION:+/p:Version=$APP_VERSION}
 
 # Stage 4: Frontend dependencies
 # Bun is the package manager and script runner, but the Angular CLI still runs on Node


### PR DESCRIPTION
Closes #186

Fixes the release failure on v1.1.0 introduced by my own #169.

## What broke

```
[main 51ec4da] Bump version to 1.1.0 [skip ci]
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Commits must have verified signatures.
remote: - Changes must be made through a pull request.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
```

`main` requires signed commits and PRs, so a `GITHUB_TOKEN` push cannot land. The job failed *before* the build, so the release published nothing — worse than the stale-version bug it was fixing. I should have checked the branch protection rules before writing a workflow that pushes.

## Fix

Do not touch the repository during a release. The requirement was only that the **image** reports the released version:

1. Derive `VERSION` from `release.tag_name` (still validated as semver)
2. Pass it to the Docker build as `APP_VERSION`
3. `Dockerfile` turns it into `/p:Version=$APP_VERSION` on `dotnet publish`, only when set
4. `Directory.Build.props` reads `application.properties` only when `Version` was not supplied

No commit, no push, no signature or PR requirement. The tag becomes the source of truth for what a release reports; `application.properties` stays the local default.

`permissions` drops back to `contents: read`.

## Verification

Built both ways and read the shipped assembly:

```
APP_VERSION=1.1.0  ->  ProductVersion=1.1.0
(no APP_VERSION)   ->  ProductVersion=0.1.1   (fallback to application.properties)
```

So a v1.1.0 release now produces an image reporting `v1.1.0`, and local builds are unchanged.