### PR TITLE
Stop offering an MP3 conversion of a source that is already MP3

### DIFF
--- a/src/ArgonFetch.Application/Services/ProxyUrlBuilder.cs
+++ b/src/ArgonFetch.Application/Services/ProxyUrlBuilder.cs
@@ -112,7 +112,11 @@ namespace ArgonFetch.Application.Services
             // generation of quality, so it belongs in the list beside the sources it is made
             // from - and stating its bitrate stops "MP3" from being the one option whose
             // quality nobody can see.
-            if (isAudio && renditions.Count > 0)
+            //
+            // Not offered when the source is already MP3, as SoundCloud's is: re-encoding it at
+            // a higher bitrate produces a larger file that sounds worse, which is not a choice
+            // worth putting in front of anyone.
+            if (isAudio && renditions.Count > 0 && !IsMp3(renditions[0]))
             {
                 renditions.Add(new MediaRenditionDto
                 {
@@ -131,6 +135,9 @@ namespace ArgonFetch.Application.Services
 
             return renditions;
         }
+
+        private static bool IsMp3(MediaRenditionDto rendition) =>
+            rendition.MimeType.Equals("audio/mpeg", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// The extension and media type the client will get. A recognised source container is

--- a/src/ArgonFetch.Tests/ProxyUrlBuilderTests.cs
+++ b/src/ArgonFetch.Tests/ProxyUrlBuilderTests.cs
@@ -49,6 +49,47 @@ namespace ArgonFetch.Tests
             cache.Verify(c => c.CacheSingleUrl(It.IsAny<string>(), true, "audio/webm", null), Times.Once);
         }
 
+        [Fact]
+        public void BuildRenditions_OffersAnMp3Conversion_ForSourcesThatAreNotAlreadyMp3()
+        {
+            var renditions = new ProxyUrlBuilder().BuildRenditions(
+                [new RenditionSource("https://example.test/opus", "251 - audio only", ".webm", null, 129, 3_400_000)],
+                CacheStub(),
+                isAudio: true);
+
+            var converted = Assert.Single(renditions, r => r.ConvertTo == "mp3");
+
+            Assert.Equal(".mp3", converted.FileExtension);
+            Assert.Equal("192 kbps", converted.Label);
+
+            // The conversion streams from the same cached source it is made from.
+            Assert.Equal(renditions[0].Key, converted.Key);
+        }
+
+        [Fact]
+        public void BuildRenditions_SkipsTheMp3Conversion_WhenTheSourceIsAlreadyMp3()
+        {
+            // SoundCloud serves MP3 directly. Re-encoding it at a higher bitrate produces a
+            // bigger file that sounds worse, so there is nothing to offer.
+            var renditions = new ProxyUrlBuilder().BuildRenditions(
+                [new RenditionSource("https://example.test/mp3", "128 kbps", ".mp3", null, 128, 2_200_000)],
+                CacheStub(),
+                isAudio: true);
+
+            Assert.DoesNotContain(renditions, r => r.ConvertTo != null);
+        }
+
+        [Fact]
+        public void BuildRenditions_OffersNoConversionForVideo()
+        {
+            var renditions = new ProxyUrlBuilder().BuildRenditions(
+                [new RenditionSource("https://example.test/mp4", "1080p", ".mp4", 1080, 4000, 80_000_000)],
+                CacheStub(),
+                isAudio: false);
+
+            Assert.DoesNotContain(renditions, r => r.ConvertTo != null);
+        }
+
         [Theory]
         [InlineData(".webm", true, "audio/webm")]
         [InlineData(".webm", false, "video/webm")]


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
SoundCloud serves progressive MP3, so its tracks came back offering a "192 kbps MP3" conversion of a 128 kbps MP3 source - a larger file that sounds worse, produced by re-encoding, and presented as if it were an upgrade.

The conversion is now only offered when the source it would be made from is something other than MP3, which is the case that motivated offering it at all: Opus and AAC do not play everywhere.

## Testing
Found by testing SoundCloud end to end against a live API:
- Track fetch works: title, author, cover art, and a single `128 kbps .mp3` rendition. Streaming it returns 2,208,495 bytes, mp3 @ 128 kbps, 138s - and no conversion is offered any more.
- Before this change the same track also listed `192 kbps MP3 converted`, which produced 3,312,161 bytes of re-encoded audio.
- YouTube is unaffected: its Opus and AAC sources still offer the MP3 conversion.

Two unit tests cover both directions, plus one asserting video never offers a conversion. 27 tests pass.

Also observed while testing SoundCloud, not changed here:
- DRM-protected tracks answer `404 Resource Not Found`. yt-dlp reports them as DRM protected, so the status is misleading - worth mapping to something clearer.
- `/sets/` playlist links answer `404`, and user profile links `415`. Both are known gaps (#76).

## Impact
Fewer options for MP3 sources, none of which were worth having. No API shape change.

## Issue related to PR
- Resolves #

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
