### PR TITLE
Honour Range requests on the media stream endpoint

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -471,6 +471,26 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -501,6 +521,49 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "206": {
+            "description": "Partial Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "416": {
+            "description": "Range Not Satisfiable",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }

--- a/src/ArgonFetch.API/Controllers/StreamController.cs
+++ b/src/ArgonFetch.API/Controllers/StreamController.cs
@@ -18,6 +18,9 @@ namespace ArgonFetch.API.Controllers
         }
 
         [HttpGet("Combined/{key}", Name = "Combined")]
+        // Muxed on the fly, so its length is unknown and it cannot be seeked within.
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> StreamCombinedMedia([FromRoute] string key, CancellationToken cancellationToken)
         {
             var query = new StreamCombinedMediaQuery(key, Response, cancellationToken);
@@ -39,9 +42,15 @@ namespace ArgonFetch.API.Controllers
         /// source untouched, which is faster and avoids a re-encode.
         /// </param>
         [HttpGet("Media/{key}", Name = "Media")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status206PartialContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status416RangeNotSatisfiable)]
         public async Task<IActionResult> StreamMedia([FromRoute] string key, CancellationToken cancellationToken, [FromQuery] string? format = null)
         {
-            var query = new StreamMediaQuery(key, Response, cancellationToken, format);
+            // The Range header is read here rather than in the handler so the query stays
+            // something that can be constructed without an HttpRequest.
+            var query = new StreamMediaQuery(key, Response, cancellationToken, format, Request.Headers.Range);
             var result = await _mediator.Send(query, cancellationToken);
 
             // Handle the result if response hasn't started

--- a/src/ArgonFetch.Application/Interfaces/IAcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Application/Interfaces/IAcceleratedDownloadService.cs
@@ -1,4 +1,6 @@
-﻿namespace ArgonFetch.Application.Interfaces
+﻿using ArgonFetch.Application.Services;
+
+namespace ArgonFetch.Application.Interfaces
 {
     public interface IAcceleratedDownloadService
     {
@@ -7,11 +9,16 @@
             string? proxy = null,
             CancellationToken cancellationToken = default);
 
+        /// <param name="range">
+        /// Window of the resource to write, or null for all of it. Set when a client is
+        /// seeking or resuming, in which case only these bytes may reach the output.
+        /// </param>
         Task StreamWithAccelerationAsync(
             string url,
             Stream outputStream,
             IProgress<double>? progress = null,
             string? proxy = null,
+            ByteRange? range = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
@@ -9,13 +9,25 @@ namespace ArgonFetch.Application.Queries
 {
     public class StreamMediaQuery : IRequest<StreamResult>
     {
-        public StreamMediaQuery(string key, HttpResponse response, CancellationToken cancellationToken, string? format = null)
+        public StreamMediaQuery(
+            string key,
+            HttpResponse response,
+            CancellationToken cancellationToken,
+            string? format = null,
+            string? rangeHeader = null)
         {
             Key = key;
             Response = response;
             CancellationToken = cancellationToken;
             Format = format;
+            RangeHeader = rangeHeader;
         }
+
+        /// <summary>
+        /// The caller's Range header, if it sent one. Honoured only where bytes are passed
+        /// through: a conversion has no fixed length to seek within.
+        /// </summary>
+        public string? RangeHeader { get; }
 
         /// <summary>
         /// Container the caller insists on, currently only "mp3". Null serves the source
@@ -117,10 +129,43 @@ namespace ArgonFetch.Application.Queries
                         proxy,
                         request.CancellationToken);
 
+                    ByteRange? window = null;
+
                     if (upstreamLength.HasValue)
                     {
-                        request.Response.ContentLength = upstreamLength.Value;
-                        _logger.LogInformation("Declared Content-Length {Length} for {Url}", upstreamLength.Value, mediaUrl);
+                        var total = upstreamLength.Value;
+
+                        // Advertised only here, where it is true: the bytes come from a source
+                        // that serves ranges and reach the caller untouched, so a seek can be
+                        // answered exactly.
+                        request.Response.Headers.AcceptRanges = "bytes";
+
+                        switch (Services.RangeHeader.Parse(request.RangeHeader, total, out var requested))
+                        {
+                            case RangeRequest.Satisfiable:
+                                window = requested;
+                                request.Response.StatusCode = StatusCodes.Status206PartialContent;
+                                request.Response.Headers.ContentRange = $"bytes {requested.From}-{requested.To}/{total}";
+                                request.Response.ContentLength = requested.Length;
+
+                                _logger.LogInformation("Serving bytes {From}-{To} of {Total} for {Url}",
+                                    requested.From, requested.To, total, mediaUrl);
+                                break;
+
+                            case RangeRequest.Unsatisfiable:
+                                // Nothing of the resource lies in the asked-for window, so the
+                                // caller is told how long it actually is and given no body.
+                                request.Response.StatusCode = StatusCodes.Status416RangeNotSatisfiable;
+                                request.Response.Headers.ContentRange = $"bytes */{total}";
+                                request.Response.ContentLength = 0;
+
+                                return StreamResult.Success();
+
+                            default:
+                                request.Response.ContentLength = total;
+                                _logger.LogInformation("Declared Content-Length {Length} for {Url}", total, mediaUrl);
+                                break;
+                        }
                     }
                     else
                     {
@@ -135,6 +180,7 @@ namespace ArgonFetch.Application.Queries
                         request.Response.Body,
                         null, // No progress reporting needed here
                         proxy,
+                        window,
                         request.CancellationToken);
                 }
 

--- a/src/ArgonFetch.Application/Services/ByteRange.cs
+++ b/src/ArgonFetch.Application/Services/ByteRange.cs
@@ -1,0 +1,99 @@
+namespace ArgonFetch.Application.Services
+{
+    /// <summary>A resolved byte range, inclusive at both ends as HTTP defines it.</summary>
+    public readonly record struct ByteRange(long From, long To)
+    {
+        public long Length => To - From + 1;
+    }
+
+    /// <summary>What a Range header asked for, once weighed against the resource's length.</summary>
+    public enum RangeRequest
+    {
+        /// <summary>No range asked for, or one this server does not honour. Serve the whole thing.</summary>
+        None,
+
+        /// <summary>A range that can be served: reply 206 with the resolved window.</summary>
+        Satisfiable,
+
+        /// <summary>A range that starts past the end of the resource: reply 416.</summary>
+        Unsatisfiable
+    }
+
+    /// <summary>
+    /// Reads the Range request header.
+    /// <para>
+    /// Only single ranges are honoured. Multipart responses exist in the specification and
+    /// almost nothing asks for them - players and download managers ask for one window at a
+    /// time - so a multi-range request is served whole rather than half-answered.
+    /// </para>
+    /// </summary>
+    public static class RangeHeader
+    {
+        public static RangeRequest Parse(string? header, long totalLength, out ByteRange range)
+        {
+            range = default;
+
+            if (string.IsNullOrWhiteSpace(header) || totalLength <= 0)
+                return RangeRequest.None;
+
+            const string unitPrefix = "bytes=";
+
+            // Surrounding whitespace is the transport's, not the client's. Anything else out
+            // of shape - including a space around the "=" - is left unhonoured rather than
+            // guessed at.
+            var value = header.Trim();
+
+            if (!value.StartsWith(unitPrefix, StringComparison.OrdinalIgnoreCase))
+                return RangeRequest.None;
+
+            var spec = value[unitPrefix.Length..].Trim();
+
+            // More than one range asked for; serving the first would be a lie by omission.
+            if (spec.Contains(','))
+                return RangeRequest.None;
+
+            var separator = spec.IndexOf('-');
+
+            if (separator < 0)
+                return RangeRequest.None;
+
+            var fromText = spec[..separator].Trim();
+            var toText = spec[(separator + 1)..].Trim();
+
+            // "bytes=-500" asks for the last 500 bytes rather than a range starting at zero.
+            if (fromText.Length == 0)
+            {
+                if (!long.TryParse(toText, out var suffixLength) || suffixLength <= 0)
+                    return RangeRequest.None;
+
+                var start = Math.Max(0, totalLength - suffixLength);
+                range = new ByteRange(start, totalLength - 1);
+
+                return RangeRequest.Satisfiable;
+            }
+
+            if (!long.TryParse(fromText, out var from) || from < 0)
+                return RangeRequest.None;
+
+            if (from >= totalLength)
+                return RangeRequest.Unsatisfiable;
+
+            // "bytes=500-" runs to the end.
+            if (toText.Length == 0)
+            {
+                range = new ByteRange(from, totalLength - 1);
+
+                return RangeRequest.Satisfiable;
+            }
+
+            if (!long.TryParse(toText, out var to) || to < from)
+                return RangeRequest.None;
+
+            // An end past the resource is clamped rather than refused, which is what the
+            // specification asks for and what every client expects.
+            range = new ByteRange(from, Math.Min(to, totalLength - 1));
+
+            return RangeRequest.Satisfiable;
+        }
+    }
+}

--- a/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
@@ -30,7 +30,7 @@ namespace ArgonFetch.Infrastructure.Services
             CancellationToken cancellationToken = default)
         {
             var memoryStream = new MemoryStream();
-            await StreamWithAccelerationAsync(url, memoryStream, null, proxy, cancellationToken);
+            await StreamWithAccelerationAsync(url, memoryStream, null, proxy, cancellationToken: cancellationToken);
             memoryStream.Position = 0;
             return memoryStream;
         }
@@ -71,6 +71,7 @@ namespace ArgonFetch.Infrastructure.Services
             Stream outputStream,
             IProgress<double>? progress = null,
             string? proxy = null,
+            ByteRange? range = null,
             CancellationToken cancellationToken = default)
         {
             // Counts what has already been handed to the caller. Once any byte is written,
@@ -105,16 +106,21 @@ namespace ArgonFetch.Infrastructure.Services
                     _logger.LogInformation("Server doesn't support range requests, using single connection");
                 }
 
-                await DownloadSingleConnectionAsync(url, outputStream, progress, output, proxy, cancellationToken);
+                await DownloadSingleConnectionAsync(url, outputStream, progress, output, proxy, range, cancellationToken);
                 return;
             }
+
+            // Serving a window rather than the file: the caller is seeking or resuming, and
+            // only the requested bytes may be written or the response will not line up with
+            // the Content-Range it announced.
+            var window = range ?? new ByteRange(0, contentLength.Value - 1);
 
             _logger.LogInformation("Starting accelerated download with {Connections} connections for {Size} bytes",
                 MAX_PARALLEL_CONNECTIONS, contentLength.Value);
 
             try
             {
-                await DownloadInChunksAsync(url, outputStream, contentLength.Value, progress, output, proxy, cancellationToken);
+                await DownloadInChunksAsync(url, outputStream, window, progress, output, proxy, cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -125,7 +131,7 @@ namespace ArgonFetch.Infrastructure.Services
             {
                 // Nothing has reached the caller yet, so starting over is safe.
                 _logger.LogWarning(ex, "Accelerated download failed before writing any output, falling back to single connection");
-                await DownloadSingleConnectionAsync(url, outputStream, progress, output, proxy, cancellationToken);
+                await DownloadSingleConnectionAsync(url, outputStream, progress, output, proxy, range, cancellationToken);
             }
         }
 
@@ -175,19 +181,21 @@ namespace ArgonFetch.Infrastructure.Services
         private async Task DownloadInChunksAsync(
             string url,
             Stream outputStream,
-            long contentLength,
+            ByteRange window,
             IProgress<double>? progress,
             OutputTracker output,
             string? proxy,
             CancellationToken cancellationToken)
         {
+            var contentLength = window.Length;
             var chunkSize = Math.Clamp(contentLength / (MAX_PARALLEL_CONNECTIONS * 2), MIN_CHUNK_SIZE, MAX_CHUNK_SIZE);
             var chunks = new List<(long start, long end)>();
 
-            // Calculate chunks
-            for (long i = 0; i < contentLength; i += chunkSize)
+            // Chunks are offsets into the resource, not into the window, so a request for the
+            // tail of a file still asks the source for the right bytes.
+            for (var i = window.From; i <= window.To; i += chunkSize)
             {
-                var end = Math.Min(i + chunkSize - 1, contentLength - 1);
+                var end = Math.Min(i + chunkSize - 1, window.To);
                 chunks.Add((i, end));
             }
 
@@ -267,13 +275,16 @@ namespace ArgonFetch.Infrastructure.Services
             IProgress<double>? progress,
             OutputTracker output,
             string? proxy,
+            ByteRange? range,
             CancellationToken cancellationToken)
         {
             var httpClient = _mediaHttpClients.For(proxy);
 
             // Ranged from the first byte: an unranged GET is refused for signed media URLs.
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            request.Headers.Range = new RangeHeaderValue(0, null);
+            request.Headers.Range = range.HasValue
+                ? new RangeHeaderValue(range.Value.From, range.Value.To)
+                : new RangeHeaderValue(0, null);
 
             using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             response.EnsureSuccessStatusCode();

--- a/src/ArgonFetch.Tests/RangeHeaderTests.cs
+++ b/src/ArgonFetch.Tests/RangeHeaderTests.cs
@@ -1,0 +1,57 @@
+using ArgonFetch.Application.Services;
+
+namespace ArgonFetch.Tests
+{
+    public class RangeHeaderTests
+    {
+        private const long Total = 1000;
+
+        [Theory]
+        [InlineData("bytes=0-499", 0, 499)]
+        [InlineData("bytes=500-", 500, 999)]
+        [InlineData("bytes=-200", 800, 999)]
+        [InlineData("bytes=0-", 0, 999)]
+        [InlineData("bytes=999-999", 999, 999)]
+        // An end past the resource is clamped, which is what clients expect.
+        [InlineData("bytes=900-5000", 900, 999)]
+        // A suffix longer than the resource is the whole resource.
+        [InlineData("bytes=-5000", 0, 999)]
+        [InlineData(" bytes=10-20 ", 10, 20)]
+        [InlineData("BYTES=10-20", 10, 20)]
+        public void Parse_ResolvesSatisfiableRanges(string header, long from, long to)
+        {
+            Assert.Equal(RangeRequest.Satisfiable, RangeHeader.Parse(header, Total, out var range));
+            Assert.Equal(new ByteRange(from, to), range);
+            Assert.Equal(to - from + 1, range.Length);
+        }
+
+        [Fact]
+        public void Parse_ReportsAStartPastTheEndAsUnsatisfiable()
+        {
+            Assert.Equal(RangeRequest.Unsatisfiable, RangeHeader.Parse("bytes=1000-1200", Total, out _));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("items=0-10")]      // not a byte range
+        [InlineData("bytes=abc-def")]
+        [InlineData("bytes=500")]       // no separator
+        [InlineData("bytes=300-200")]   // end before start
+        [InlineData("bytes=-0")]        // a zero-length suffix asks for nothing
+        [InlineData("bytes = 10-20")]   // a space around the separator is not the defined syntax
+        [InlineData("bytes=0-99,200-299")] // multipart, which this server does not serve
+        public void Parse_IgnoresWhatItCannotHonour(string? header)
+        {
+            // Ignored means the whole resource is served, which is always a valid answer.
+            Assert.Equal(RangeRequest.None, RangeHeader.Parse(header, Total, out _));
+        }
+
+        [Fact]
+        public void Parse_IgnoresRangesWhenTheLengthIsUnknown()
+        {
+            // Without a length there is nothing to resolve "bytes=-200" or an open end against.
+            Assert.Equal(RangeRequest.None, RangeHeader.Parse("bytes=0-99", 0, out _));
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
Seeking and resuming did not work on `/api/Stream/Media/{key}`: every request got the whole file from byte zero, whatever it asked for. A player dragging its scrubber had to refetch from the start, and an interrupted download could not be continued. The `Accept-Ranges: bytes` header the issue describes had already gone with the pass-through work, so the server was no longer claiming support it lacked - but it still could not seek.

Pass-through responses now read the `Range` header, ask the source for that window, and reply `206` with a `Content-Range`. A range starting past the end answers `416` with the real length and no body. `Accept-Ranges` is advertised only on that path, where it is true. Multi-range requests are served whole rather than half-answered, since nothing in practice asks for them and a partial answer would be worse than a complete one.

Conversions (`?format=mp3`) and muxed video are deliberately unchanged: their length is not known until they finish, so there is nothing to seek within, and they say so by not advertising ranges.

## Testing
Unit tests cover the header parsing: open-ended ranges, suffix ranges, an end past the resource being clamped, a start past the end being unsatisfiable, and everything it declines to honour - bad syntax, reversed bounds, multi-range, unknown length. 47 tests pass.

Against a running server, on a 3,433,755-byte Opus file:

| request | status | bytes |
|---|---|---|
| none | 200 | 3,433,755 |
| `bytes=0-99999` | 206 | 100,000 |
| `bytes=1000000-1099999` | 206 | 100,000 |
| `bytes=-50000` | 206 | 50,000 |
| `bytes=3400000-` | 206 | 33,755 |
| `bytes=99999999-` | 416 | 0 |
| `bytes=0-99,200-299` | 200 | 3,433,755 |

Every partial response was hashed against the matching slice of the full download - all four match byte for byte, which is what proves the chunker asks the source for offsets into the resource rather than into the window. `?format=mp3` and `/Stream/Combined` with a `Range` header still answer `200` with the full body and no `Accept-Ranges`.

The OpenAPI schema is refreshed: `/api/Stream/Media/{key}` now documents 200, 206, 404 and 416.

## Impact
No change for clients that do not send `Range`. Downloads become resumable and media becomes seekable in a browser player.

## Issue related to PR
- Resolves #120

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
