### PR TITLE
Drop the buffered download variant

### DIFF
--- a/src/ArgonFetch.Application/Interfaces/IAcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Application/Interfaces/IAcceleratedDownloadService.cs
@@ -4,11 +4,6 @@ namespace ArgonFetch.Application.Interfaces
 {
     public interface IAcceleratedDownloadService
     {
-        Task<Stream> DownloadWithAccelerationAsync(
-            string url,
-            string? proxy = null,
-            CancellationToken cancellationToken = default);
-
         /// <param name="range">
         /// Window of the resource to write, or null for all of it. Set when a client is
         /// seeking or resuming, in which case only these bytes may reach the output.

--- a/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
@@ -24,17 +24,6 @@ namespace ArgonFetch.Infrastructure.Services
             _logger = logger;
         }
 
-        public async Task<Stream> DownloadWithAccelerationAsync(
-            string url,
-            string? proxy = null,
-            CancellationToken cancellationToken = default)
-        {
-            var memoryStream = new MemoryStream();
-            await StreamWithAccelerationAsync(url, memoryStream, null, proxy, cancellationToken: cancellationToken);
-            memoryStream.Position = 0;
-            return memoryStream;
-        }
-
         /// <summary>
         /// Length the upstream reports, or null when it does not report one. A failure here is
         /// not fatal - the caller simply cannot declare Content-Length and the response is chunked.


### PR DESCRIPTION
## Type of Change
- [x] Refactoring

## Description
`DownloadWithAccelerationAsync` copied an entire download into a `MemoryStream` and handed back the buffer - gigabytes of managed heap for a large file. Nothing called it: every caller streams to the response body. It was a hazard sitting in the interface waiting for someone to reach for it, so it is gone.

The method the issue names, `GenerateCombinedMediaAsync`, no longer exists - muxed video has streamed straight to `Response.Body` for a while now. This was the same shape left over in the download service, which is what the issue''s "if nothing needs the buffered variant, delete it" prescribes.

## Testing
Confirmed the concern behind the issue is genuinely gone rather than assumed, by muxing the 4K rendition (232 MB of source) and watching the server while it streamed:

```
baseline RSS: 169 MB
  t+ 4s  RSS=170 MB  written= 6,864,896 bytes
  t+16s  RSS=170 MB  written=32,792,576 bytes
  t+36s  RSS=169 MB  written=73,871,360 bytes
peak RSS during mux: 170 MB
```

Memory stays flat while output grows, and the first bytes arrive within seconds rather than after the whole mux - which is what buffering would prevent. 47 tests pass, build is clean, and no reference to the removed method remains.

## Impact
Removes a public method from `IAcceleratedDownloadService`. No caller in this repository uses it. Anything outside that did would have been holding a whole file in memory.

## Issue related to PR
- Resolves #122

## Additional Information
Two smaller buffers remain, both bounded and both fine: `DownloadChunkAsync` holds one chunk (capped at 8MB, at most 8 in flight), and `ProxyRangeQuery` holds the range it was asked for. `ProxyUrlQuery` still returns a whole `byte[]`, but it serves cover art - and the `/api/Proxy/*` endpoints turn out to be unused by the web UI entirely, which may be worth its own issue.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
