### PR TITLE
Report DRM protected media as refused rather than missing

### DIFF
--- a/src/ArgonFetch.API/Controllers/FetchController.cs
+++ b/src/ArgonFetch.API/Controllers/FetchController.cs
@@ -71,6 +71,9 @@ namespace ArgonFetch.API.Controllers
                 return StatusCode(StatusCodes.Status415UnsupportedMediaType, new ProblemDetails
                 {
                     Title = "Unsupported Media Type",
+                    // Carried through so a caller learns which kind of unsupported this is -
+                    // DRM, or a link shape ArgonFetch does not handle yet.
+                    Detail = ex.Message,
                     Status = StatusCodes.Status415UnsupportedMediaType
                 });
             }

--- a/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
@@ -402,7 +402,16 @@ namespace ArgonFetch.Application.Queries
             while (!result.Success && --attempts > 0);
 
             if (!result.Success)
-                throw new ArgumentException($"Failed to fetch data: {string.Join(", ", result.ErrorOutput)}");
+            {
+                var errors = string.Join(", ", result.ErrorOutput);
+
+                // Separated from a plain failure because the two mean different things to
+                // whoever pasted the link: DRM is a refusal, not a bad address.
+                if (YtDlpErrors.IsDrmProtected(result.ErrorOutput))
+                    throw new NotSupportedException("This media is DRM protected and cannot be downloaded.");
+
+                throw new ArgumentException($"Failed to fetch data: {errors}");
+            }
 
             return result.Data;
         }

--- a/src/ArgonFetch.Application/Services/YtDlpErrors.cs
+++ b/src/ArgonFetch.Application/Services/YtDlpErrors.cs
@@ -1,0 +1,17 @@
+namespace ArgonFetch.Application.Services
+{
+    /// <summary>
+    /// Reads what yt-dlp printed when a fetch failed, so the API can say why rather than
+    /// treating every failure as a missing resource.
+    /// </summary>
+    public static class YtDlpErrors
+    {
+        /// <summary>
+        /// Whether the source refused because the media is DRM protected - SoundCloud does this
+        /// for licensed tracks. The track exists and the link is right, so reporting it as
+        /// missing sends the reader looking for a mistake that is not there.
+        /// </summary>
+        public static bool IsDrmProtected(IEnumerable<string>? errorOutput) =>
+            errorOutput?.Any(line => line?.Contains("DRM", StringComparison.OrdinalIgnoreCase) == true) == true;
+    }
+}

--- a/src/ArgonFetch.Tests/YtDlpErrorsTests.cs
+++ b/src/ArgonFetch.Tests/YtDlpErrorsTests.cs
@@ -1,0 +1,28 @@
+using ArgonFetch.Application.Services;
+
+namespace ArgonFetch.Tests
+{
+    public class YtDlpErrorsTests
+    {
+        [Fact]
+        public void IsDrmProtected_RecognisesTheRefusal()
+        {
+            Assert.True(YtDlpErrors.IsDrmProtected(["ERROR: [soundcloud] 253508261: This video is DRM protected"]));
+        }
+
+        [Fact]
+        public void IsDrmProtected_IgnoresOtherFailures()
+        {
+            // A missing video really is missing; only DRM gets the different answer.
+            Assert.False(YtDlpErrors.IsDrmProtected(["ERROR: [youtube] abc: Video unavailable"]));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        public void IsDrmProtected_HandlesNothingToRead(string[]? errorOutput)
+        {
+            Assert.False(YtDlpErrors.IsDrmProtected(errorOutput));
+            Assert.False(YtDlpErrors.IsDrmProtected([]));
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
SoundCloud serves DRM protected tracks for licensed catalogue and yt-dlp refuses them. That refusal came back as `404 Resource Not Found`, which sends whoever pasted the link hunting for a typo in an address that is perfectly correct.

Those now answer `415` with the reason. The `415` branch also carries the exception message through as `detail`, so a caller can tell which kind of unsupported it hit - DRM, or a link shape ArgonFetch does not handle yet.

## Testing
Against a live API, using a track yt-dlp reports as `This video is DRM protected`:

```
415  {"title":"Unsupported Media Type","status":415,
      "detail":"This media is DRM protected and cannot be downloaded."}
```

Other failures keep answering 404, which is what they are: a genuinely missing YouTube video and a dead SoundCloud link both still return `Resource Not Found`. A normal SoundCloud track still returns 200. Three unit tests cover the detection, including nothing-to-read; 50 tests pass.

## Impact
One failure mode changes status code, from 404 to 415. No API shape change - `detail` is a field `ProblemDetails` already carries.

## Issue related to PR
- Resolves #

## Additional Information
Detection matches on yt-dlp''s own wording, so a future rewording would quietly fall back to the old 404 rather than break anything.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
