### PR TITLE
Run the frontend zoneless

### DIFF
--- a/src/ArgonFetch.Frontend/angular.json
+++ b/src/ArgonFetch.Frontend/angular.json
@@ -20,9 +20,7 @@
             "outputPath": "dist/argon-fetch.frontend2",
             "index": "src/index.html",
             "browser": "src/main.ts",
-            "polyfills": [
-              "zone.js"
-            ],
+            "polyfills": [],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -84,10 +82,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ],
+            "polyfills": [],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [

--- a/src/ArgonFetch.Frontend/src/app/app.component.html
+++ b/src/ArgonFetch.Frontend/src/app/app.component.html
@@ -11,7 +11,7 @@
   </div>
 </nav>
 
-@if (maintenance) {
+@if (maintenance(); as maintenance) {
   <div class="maintenance" role="status" aria-live="polite">
     <div class="maintenance-card">
       <fa-icon [icon]="faGear" class="maintenance-icon" animation="spin"></fa-icon>
@@ -33,8 +33,8 @@
       GitHub <fa-icon [icon]="faGithub" class="footer-github-icon"></fa-icon>
     </a>
     <span class="footer-separator">•</span>
-    <span class="footer-environment">{{ environment }}</span>
+    <span class="footer-environment">{{ environment() }}</span>
     <span class="footer-separator">•</span>
-    <a href="https://github.com/ArgonFetch/ArgonFetch/releases/tag/{{ version }}" class="footer-link footer-version" target="_blank">{{ version }}</a>
+    <a href="https://github.com/ArgonFetch/ArgonFetch/releases/tag/{{ version() }}" class="footer-link footer-version" target="_blank">{{ version() }}</a>
   </div>
 </footer>

--- a/src/ArgonFetch.Frontend/src/app/app.component.ts
+++ b/src/ArgonFetch.Frontend/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
@@ -25,9 +25,12 @@ export class AppComponent {
   faGithub = faGithub;
   faGear = faGear;
   isDarkTheme$;
-  version = 'unknown';
-  environment = 'unknown';
-  maintenance: string | null = null;
+
+  // Signals rather than plain fields: these are written from a promise and a timer, and
+  // without zone.js nothing else would tell the view they changed.
+  version = signal('unknown');
+  environment = signal('unknown');
+  maintenance = signal<string | null>(null);
 
   // Polled rather than pushed: the only maintenance is a yt-dlp update that lasts seconds, so
   // one small request a minute is cheaper than any kind of live connection. While it is running
@@ -64,9 +67,9 @@ export class AppComponent {
       )
     );
 
-    this.version = appInfo.version!;
-    this.environment = appInfo.environment!;
-    this.maintenance = appInfo.maintenance ?? null;
+    this.version.set(appInfo.version!);
+    this.environment.set(appInfo.environment!);
+    this.maintenance.set(appInfo.maintenance ?? null);
     this.scheduleMaintenanceCheck();
   }
 
@@ -75,7 +78,7 @@ export class AppComponent {
 
     this.pollTimer = setTimeout(
       () => this.checkMaintenance(),
-      this.maintenance ? AppComponent.MAINTENANCE_POLL_MS : AppComponent.IDLE_POLL_MS
+      this.maintenance() ? AppComponent.MAINTENANCE_POLL_MS : AppComponent.IDLE_POLL_MS
     );
   }
 
@@ -87,7 +90,7 @@ export class AppComponent {
     );
 
     if (appInfo) {
-      this.maintenance = appInfo.maintenance ?? null;
+      this.maintenance.set(appInfo.maintenance ?? null);
     }
 
     this.scheduleMaintenanceCheck();

--- a/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.html
+++ b/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.html
@@ -9,27 +9,27 @@
       <p class="song-artist">{{ resourceInformation.mediaItems?.[0]?.author }}</p>
 
       <!-- Download Progress Bar -->
-      @if (isDownloading) {
+      @if (isDownloading()) {
         <div class="download-progress-container">
           <div class="download-info">
-            <span class="download-filename">{{ currentDownloadName }}</span>
+            <span class="download-filename">{{ currentDownloadName() }}</span>
             <div class="download-stats">
-              @if (downloadSpeed) {
-                <span class="download-speed">{{ downloadSpeed }}</span>
+              @if (downloadSpeed()) {
+                <span class="download-speed">{{ downloadSpeed() }}</span>
               }
-              @if (downloadedMB) {
+              @if (downloadedMB()) {
                 <span class="download-size">
-                  {{ downloadedMB }}@if (hasKnownTotal) { / {{ totalMB }}} MB
+                  {{ downloadedMB() }}@if (hasKnownTotal()) { / {{ totalMB() }}} MB
                 </span>
               }
-              @if (hasKnownTotal) {
-                <span class="download-percentage">{{ downloadProgress }}%</span>
+              @if (hasKnownTotal()) {
+                <span class="download-percentage">{{ downloadProgress() }}%</span>
               }
             </div>
           </div>
           <div class="progress-bar-wrapper">
-            @if (hasKnownTotal) {
-              <div class="progress-bar" [style.width.%]="downloadProgress" [style.max-width]="'100%'"></div>
+            @if (hasKnownTotal()) {
+              <div class="progress-bar" [style.width.%]="downloadProgress()" [style.max-width]="'100%'"></div>
             } @else {
               <!-- The server cannot declare a length for muxed streams, so show motion
                    rather than a number that would be invented. -->
@@ -46,10 +46,10 @@
          hover-and-boolean version had. -->
     <div class="download-button-container">
       <button type="button" class="action-button download-button"
-        [disabled]="isDownloading"
-        [cdkMenuTriggerFor]="isDownloading ? null : mainMenu"
+        [disabled]="isDownloading()"
+        [cdkMenuTriggerFor]="isDownloading() ? null : mainMenu"
         aria-label="Download">
-        @if (!isDownloading) {
+        @if (!isDownloading()) {
           <fa-icon [icon]="faDownload"></fa-icon>
         } @else {
           <fa-icon [icon]="faSpinner" class="fa-spin"></fa-icon>

--- a/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.ts
+++ b/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy, signal } from '@angular/core';
 import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
@@ -22,17 +22,19 @@ export class SingleSongContainerComponent {
   faChevronRight = faChevronRight;
   faSpinner = faSpinner;
 
-  // Download progress tracking
-  isDownloading = false;
-  downloadProgress = 0;
-  currentDownloadName = '';
-  downloadSpeed = '';
-  lastDownloadTime = 0;
-  lastDownloadBytes = 0;
-  totalBytes = 0;
-  totalMB = '';
-  hasKnownTotal = false;
-  downloadedMB = '';
+  // Download progress, all of it written from HTTP progress events. Those schedule no
+  // change detection without zone.js, so the view reads signals instead of fields.
+  isDownloading = signal(false);
+  downloadProgress = signal(0);
+  currentDownloadName = signal('');
+  downloadSpeed = signal('');
+  totalMB = signal('');
+  hasKnownTotal = signal(false);
+  downloadedMB = signal('');
+
+  // Not rendered - only used to work out the speed between two events.
+  private lastDownloadTime = 0;
+  private lastDownloadBytes = 0;
 
   constructor(
     private http: HttpClient,
@@ -63,7 +65,7 @@ export class SingleSongContainerComponent {
 
   /** Downloads one rendition, converted or passed through as the server described it. */
   async onDownloadRendition(rendition: MediaRenditionDto) {
-    if (this.isDownloading) {
+    if (this.isDownloading()) {
       return;
     }
 
@@ -80,7 +82,7 @@ export class SingleSongContainerComponent {
   }
 
   async onDownload(quality: 'best' | 'medium' | 'worst', type: 'combined' | 'audio') {
-    if (this.isDownloading) {
+    if (this.isDownloading()) {
       return; // Prevent multiple downloads at once
     }
 
@@ -121,21 +123,20 @@ export class SingleSongContainerComponent {
       return;
     }
 
-    this.currentDownloadName = `${filename}${extension}`;
-    await this.downloadFile(url, this.currentDownloadName);
+    this.currentDownloadName.set(`${filename}${extension}`);
+    await this.downloadFile(url, this.currentDownloadName());
   }
 
   private async downloadFile(url: string, filename: string) {
-    this.isDownloading = true;
-    this.downloadProgress = 0;
-    this.downloadSpeed = '';
+    this.isDownloading.set(true);
+    this.downloadProgress.set(0);
+    this.downloadSpeed.set('');
     this.lastDownloadTime = Date.now();
     this.lastDownloadBytes = 0;
-    this.currentDownloadName = filename;
-    this.totalBytes = 0;
-    this.totalMB = '';
-    this.hasKnownTotal = false;
-    this.downloadedMB = '0';
+    this.currentDownloadName.set(filename);
+    this.totalMB.set('');
+    this.hasKnownTotal.set(false);
+    this.downloadedMB.set('0');
 
     // Use HttpClient to download with progress tracking.
     // Errors arrive on the error callback, not as a thrown exception - subscribe()
@@ -147,28 +148,25 @@ export class SingleSongContainerComponent {
     }).subscribe({
         next: (event) => {
           if (event.type === HttpEventType.DownloadProgress) {
-            // Store total bytes if available
-            this.totalBytes = event.total || 0;
-
             // Only report a percentage when the real transfer size is known. The size used
             // to be guessed from hardcoded per-quality figures, which produced a bar that
             // bore no relation to the transfer and then sat at 95% until it finished.
             // The combined endpoint muxes on the fly, so it genuinely cannot send a length;
             // there the bar runs indeterminate and the byte counter carries the information.
-            this.hasKnownTotal = !!event.total;
+            this.hasKnownTotal.set(!!event.total);
 
             if (event.total) {
               const progress = Math.round((event.loaded / event.total) * 100);
-              this.downloadProgress = Math.min(100, Math.max(0, progress));
-              this.totalMB = (event.total / 1024 / 1024).toFixed(1);
+              this.downloadProgress.set(Math.min(100, Math.max(0, progress)));
+              this.totalMB.set((event.total / 1024 / 1024).toFixed(1));
             } else {
-              this.downloadProgress = 0;
-              this.totalMB = '';
+              this.downloadProgress.set(0);
+              this.totalMB.set('');
             }
 
             // Always truthful, known on every event, and the only figure available when
             // the server cannot declare a length.
-            this.downloadedMB = (event.loaded / 1024 / 1024).toFixed(1);
+            this.downloadedMB.set((event.loaded / 1024 / 1024).toFixed(1));
 
             // Calculate download speed
             const currentTime = Date.now();
@@ -177,7 +175,7 @@ export class SingleSongContainerComponent {
             if (timeDiff > 0.5) { // Update speed every 0.5 seconds
               const bytesDiff = event.loaded - this.lastDownloadBytes;
               const speed = bytesDiff / timeDiff; // bytes per second
-              this.downloadSpeed = this.formatSpeed(speed);
+              this.downloadSpeed.set(this.formatSpeed(speed));
 
               this.lastDownloadTime = currentTime;
               this.lastDownloadBytes = event.loaded;
@@ -199,14 +197,13 @@ export class SingleSongContainerComponent {
   }
 
   private resetDownloadState() {
-    this.isDownloading = false;
-    this.downloadProgress = 0;
-    this.totalMB = '';
-    this.hasKnownTotal = false;
-    this.currentDownloadName = '';
-    this.downloadSpeed = '';
-    this.totalBytes = 0;
-    this.downloadedMB = '';
+    this.isDownloading.set(false);
+    this.downloadProgress.set(0);
+    this.totalMB.set('');
+    this.hasKnownTotal.set(false);
+    this.currentDownloadName.set('');
+    this.downloadSpeed.set('');
+    this.downloadedMB.set('');
   }
 
   private saveBlob(blob: Blob, filename: string) {

--- a/src/ArgonFetch.Frontend/src/app/content-skeleton-loader/content-skeleton-loader.component.ts
+++ b/src/ArgonFetch.Frontend/src/app/content-skeleton-loader/content-skeleton-loader.component.ts
@@ -1,5 +1,5 @@
 
-import { Component, Input, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'app-content-skeleton-loader',
@@ -9,14 +9,10 @@ import { Component, Input, OnInit, ChangeDetectionStrategy } from '@angular/core
   changeDetection: ChangeDetectionStrategy.Eager,
   styleUrl: './content-skeleton-loader.component.scss'
 })
-export class ContentSkeletonLoaderComponent implements OnInit {
+export class ContentSkeletonLoaderComponent {
   @Input() type: 'single-song' | 'playlist' | 'unknown' = 'unknown';
+  // Set by the caller, which always passes true. The timer that used to re-set it here
+  // did nothing the binding had not already done, and would have stopped running silently
+  // once the app went zoneless.
   @Input() animate: boolean = true;
-  
-  ngOnInit() {
-    // Ensure animation starts after component is rendered
-    setTimeout(() => {
-      this.animate = true;
-    }, 10);
-  }
 }

--- a/src/ArgonFetch.Frontend/src/app/home/home.component.html
+++ b/src/ArgonFetch.Frontend/src/app/home/home.component.html
@@ -1,5 +1,5 @@
 <main class="main-content">
-  @if (mediaType || resourceInformation || isLoading) {
+  @if (mediaType() || resourceInformation() || isLoading()) {
     <div class="when-content-arrives-spacing"></div>
   }
   <div class="hero">
@@ -16,24 +16,26 @@
           </button>
         }
       </div>
-      <button type="submit" class="search-btn" [disabled]="isLoading">
+      <button type="submit" class="search-btn" [disabled]="isLoading()">
         <fa-icon [icon]="faSearch"></fa-icon>
-        {{ isLoading ? 'Searching...' : 'Search' }}
+        {{ isLoading() ? 'Searching...' : 'Search' }}
       </button>
     </form>
 
     <!-- Skeleton Loader -->
-    @if (isLoading) {
-      <app-content-skeleton-loader [type]="loaderType" [animate]="true" class="content-container" />
+    @if (isLoading()) {
+      <app-content-skeleton-loader [type]="loaderType()" [animate]="true" class="content-container" />
     }
 
     <!-- Actual Content -->
     <div class="content-container">
-      @if (resourceInformation?.type === mediaTypeEnum.Media && resourceInformation) {
-        <app-single-song-container [resourceInformation]="resourceInformation" />
-      }
-      @if (resourceInformation?.type === mediaTypeEnum.PlayList && resourceInformation) {
-        <app-playlist-container [resourceInformation]="resourceInformation" />
+      @if (resourceInformation(); as resource) {
+        @if (resource.type === mediaTypeEnum.Media) {
+          <app-single-song-container [resourceInformation]="resource" />
+        }
+        @if (resource.type === mediaTypeEnum.PlayList) {
+          <app-playlist-container [resourceInformation]="resource" />
+        }
       }
     </div>
 

--- a/src/ArgonFetch.Frontend/src/app/home/home.component.ts
+++ b/src/ArgonFetch.Frontend/src/app/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DestroyRef, ChangeDetectionStrategy, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
@@ -34,11 +34,13 @@ export class HomeComponent {
   url: string = '';
   faWarning = faTriangleExclamation;
 
-  isLoading: boolean = false;
-  loaderType: 'single-song' | 'playlist' | 'unknown' = 'unknown';
+  // Signals: every one of these is written from an HTTP subscribe, which schedules no
+  // change detection of its own now that the app runs without zone.js.
+  isLoading = signal(false);
+  loaderType = signal<'single-song' | 'playlist' | 'unknown'>('unknown');
 
-  resourceInformation: ResourceInformationDto | undefined;
-  mediaType: MediaType | undefined;
+  resourceInformation = signal<ResourceInformationDto | undefined>(undefined);
+  mediaType = signal<MediaType | undefined>(undefined);
 
   constructor(
     private fetchService: FetchService,
@@ -49,7 +51,7 @@ export class HomeComponent {
   async download() {
     // Enter can fire while a fetch is already running; the Search button is disabled
     // for the same reason.
-    if (this.isLoading) {
+    if (this.isLoading()) {
       return;
     }
 
@@ -63,11 +65,11 @@ export class HomeComponent {
     }
 
     // Reset previous content
-    this.resourceInformation = undefined;
+    this.resourceInformation.set(undefined);
 
     // Show loader
-    this.isLoading = true;
-    this.loaderType = 'single-song'; // Default to single-song loader
+    this.isLoading.set(true);
+    this.loaderType.set('single-song'); // Default to single-song loader
 
     this.fetchResource();
   }
@@ -78,17 +80,13 @@ export class HomeComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (resourceInformation: ResourceInformationDto) => {
-          this.resourceInformation = resourceInformation;
-          this.mediaType = resourceInformation.type;
+          this.resourceInformation.set(resourceInformation);
+          this.mediaType.set(resourceInformation.type);
 
           // Update loader type based on actual media type
-          if (resourceInformation.type === MediaType.PlayList) {
-            this.loaderType = 'playlist';
-          } else {
-            this.loaderType = 'single-song';
-          }
+          this.loaderType.set(resourceInformation.type === MediaType.PlayList ? 'playlist' : 'single-song');
 
-          this.isLoading = false;
+          this.isLoading.set(false);
         },
         error: (error: any) => {
           if (error.status === 404) {
@@ -105,7 +103,7 @@ export class HomeComponent {
   }
 
   private handleError(title: string, confirmationText: string) {
-    this.isLoading = false;
+    this.isLoading.set(false);
     this.notifications.show({ title, message: confirmationText, tone: 'error' });
   }
 }

--- a/src/ArgonFetch.Frontend/src/main.ts
+++ b/src/ArgonFetch.Frontend/src/main.ts
@@ -1,7 +1,9 @@
-import { provideZoneChangeDetection } from "@angular/core";
+import { provideZonelessChangeDetection } from "@angular/core";
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
-bootstrapApplication(AppComponent, {...appConfig, providers: [provideZoneChangeDetection(), ...appConfig.providers]})
+// Zoneless: the app no longer ships zone.js, and change detection runs off signals,
+// template events and the async pipe rather than off every patched timer and XHR.
+bootstrapApplication(AppComponent, {...appConfig, providers: [provideZonelessChangeDetection(), ...appConfig.providers]})
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Type of Change
- [x] Refactoring
- [x] UI/UX improvement

## Description
zone.js patches every timer, promise and XHR so Angular can guess when to re-render. Dropping it takes **37kB off the bundle - 12kB over the wire** (604kB → 566kB raw, 150kB → 138kB gzipped) and makes the render triggers explicit rather than ambient.

There is no migration schematic for this. Angular 22 ships `zoneless` as an option for *new* applications (`ng new --zoneless`) and the `@angular/core` collection has no zoneless migration, so the switch itself is two lines - `provideZonelessChangeDetection()` and an empty `polyfills` array - and the actual work is the state that relied on zone.js noticing it changed:

- **`HomeComponent`** - the fetch result, media type, loading flag and loader type, all written from an HTTP subscribe
- **`SingleSongContainerComponent`** - the download progress, written from HTTP progress events several times a second
- **`AppComponent`** - version, environment and maintenance state, written from a promise and a polling timer

Those are signals now. Fields that only feed a calculation and are never rendered (`lastDownloadTime`, `lastDownloadBytes`) stayed plain fields, and are marked private to say so.

`ContentSkeletonLoaderComponent` lost an `ngOnInit` that re-set an `@Input` to the value it was already bound to, on a 10ms timer. It did nothing before this change and would have quietly done nothing differently after it.

## Testing
Driven in a real browser against a live API, because the failure mode here is "renders once, then silently stops updating" - which a unit test and a passing build both miss:

- `window.Zone` is `undefined`, so zone.js is genuinely gone rather than merely unused.
- Search flow: skeleton appears while loading, result renders when the request returns.
- **Download progress moves**: on the 4K mux, the counter walked 0 → 0.3 → 0.9 → 1.0 → 3.6 → 11.9 MB. This is the one that matters - HTTP progress events into signals. A first attempt looked flat, which turned out to be a 3MB file finishing between samples rather than a bug.
- Maintenance overlay appears when the server reports it and **clears itself** when it stops - that clearing is a `setTimeout` writing a signal, exactly what zone.js used to cover.
- Toasts appear and auto-dismiss on their timer.
- Menus, downloads and file naming all still work; no console or page errors throughout.

## Impact
No behaviour change intended, and none observed. The app is lighter and change detection now runs on signal writes, template events and the async pipe instead of on every patched async operation.

## Issue related to PR
- Resolves #

## Additional Information
Anything added later that writes component state from a timer or a subscribe has to be a signal - a plain field will render once and then look frozen. That is the trade for the 12kB.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
