### PR TITLE
Confirm the matched recording instead of trusting search order

### DIFF
--- a/src/ArgonFetch.Application/ArgonFetch.Application.csproj
+++ b/src/ArgonFetch.Application/ArgonFetch.Application.csproj
@@ -18,6 +18,12 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <!-- Matching is a pile of heuristics whose individual steps are worth testing on their
+       own; without this a failing track can only be diagnosed through the whole pipeline. -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="ArgonFetch.Tests" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.7.1" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />

--- a/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
@@ -34,6 +34,15 @@ namespace ArgonFetch.Application.Queries
         private readonly IProxyUrlBuilder _proxyUrlBuilder;
         private readonly IProxyPool _proxyPool;
 
+        // Wrong-recording candidates come in runs - a radio edit, a remaster and a twelve-inch
+        // mix all sit above the album version - so checking a couple past the leader is worth a
+        // fetch each. Beyond that the search itself was wrong.
+        private const int MaxVerificationAttempts = 3;
+
+        // A release and its Spotify entry differ by a second or two of trailing silence. A radio
+        // edit differs by a minute, which is what this has to catch.
+        private const double VerificationToleranceSec = 12.0;
+
         // The proxy the last extraction went through. Media URLs are signed for the IP that
         // requested them, so it has to travel with them to the stream endpoint.
         private string? _fetchProxy;
@@ -323,6 +332,70 @@ namespace ArgonFetch.Application.Queries
             (long?)(format.FileSize ?? format.ApproximateFileSize));
 
         /// <summary>
+        /// Fetches candidates in order until one turns out to be the requested recording.
+        /// </summary>
+        /// <param name="requireDuration">
+        /// Whether a candidate whose length cannot be confirmed may be accepted. It may on the
+        /// normal path, where the title and credit already matched; it may not when the title
+        /// was disregarded, because then the duration is the only thing identifying the track.
+        /// </param>
+        private async Task<VideoData?> FetchVerifiedAgainstSpotify(
+            IReadOnlyList<MatchCandidate> ranked,
+            List<MatchCandidate> candidates,
+            List<YTMusicAPI.Model.Domain.Track> results,
+            SpotifyTrackMetadata track,
+            CancellationToken cancellationToken,
+            bool requireDuration = false)
+        {
+            VideoData? firstFetched = null;
+
+            // Two beyond the leader. Each attempt is a yt-dlp call, and a search whose first
+            // three results are all the wrong recording is not one more fetch away from success.
+            foreach (var candidate in ranked.Take(MaxVerificationAttempts))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Reference equality, not IndexOf: MatchCandidate is a record, so two results with
+                // the same title, artist and length would compare equal and resolve to the wrong URL.
+                var url = results[candidates.FindIndex(c => ReferenceEquals(c, candidate))].Url;
+
+                VideoData fetched;
+
+                try
+                {
+                    fetched = await YT_DLP_Fetch(url);
+                }
+                catch (ArgumentException)
+                {
+                    // A candidate that cannot be fetched is no worse than one that does not fit.
+                    continue;
+                }
+
+                firstFetched ??= fetched;
+
+                if (DurationFits(fetched, track.DurationMs))
+                    return fetched;
+            }
+
+            // Nothing was confirmed. On the normal path the leader had already matched on title
+            // and credit, so it is still the best answer available; on the credit-only path there
+            // is nothing left to identify it by, and a wrong recording is worse than none.
+            return requireDuration ? null : firstFetched;
+        }
+
+        /// <summary>
+        /// Whether a fetched result runs to the length the request asked for. Unknown lengths on
+        /// either side are not evidence against a candidate.
+        /// </summary>
+        private static bool DurationFits(VideoData fetched, long wantedMs)
+        {
+            if (wantedMs <= 0 || fetched.Duration is not > 0)
+                return false;
+
+            return Math.Abs(fetched.Duration.Value - wantedMs / 1000.0) <= VerificationToleranceSec;
+        }
+
+        /// <summary>
         /// Opus is worth roughly 20% more than AAC at the same bitrate, so it is weighted that
         /// way rather than compared on the raw number. YouTube offers the two within a kbps of
         /// each other, which would otherwise make the pick a coin toss.
@@ -441,21 +514,32 @@ namespace ArgonFetch.Application.Queries
                     r.Author ?? string.Empty))
                 .ToList();
 
-            var best = YouTubeMusicMatcher.BestMatch(
+            var ranked = YouTubeMusicMatcher.RankMatches(
                 candidates,
                 track.Title,
                 track.Artist,
                 track.DurationMs,
                 officialShelf: true);
 
-            if (best is null)
+            // Search never reports a duration - YTMusicAPI returns null for every row - so the
+            // one signal that separates an album version from its radio edit is missing while
+            // ranking. Fetching a candidate does report it, so the pick is checked rather than
+            // trusted, and the next candidate tried when it does not fit.
+            var result = await FetchVerifiedAgainstSpotify(ranked, candidates, results, track, cancellationToken);
+
+            if (result is null)
+            {
+                // Titles are often translated - Spotify says "REVENGE OF B" where YouTube Music
+                // says the Japanese original - and then no candidate shares a single word with
+                // what was asked for. The credit still matches, and the duration decides, so
+                // this pass drops the title requirement and leans on the check instead.
+                var byCredit = YouTubeMusicMatcher.RankByCreditOnly(candidates, track.Artist);
+
+                result = await FetchVerifiedAgainstSpotify(byCredit, candidates, results, track, cancellationToken, requireDuration: true);
+            }
+
+            if (result is null)
                 throw new ArgumentException($"No YouTube Music match found for '{searchQuery}'");
-
-            // Reference equality, not IndexOf: MatchCandidate is a record, so two results with the
-            // same title, artist and length would compare equal and resolve to the wrong URL.
-            var ytmTrackUrl = results[candidates.FindIndex(c => ReferenceEquals(c, best))].Url;
-
-            var result = await YT_DLP_Fetch(ytmTrackUrl);
 
             var audioUrls = ExtractThreeAudioQualitiesAndCacheNewUrl(result.Formats);
 

--- a/src/ArgonFetch.Application/Services/YouTubeMusicMatcher.cs
+++ b/src/ArgonFetch.Application/Services/YouTubeMusicMatcher.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace ArgonFetch.Application.Services
 {
@@ -30,7 +30,7 @@ namespace ArgonFetch.Application.Services
         {
             "cover", "covers", "karaoke", "instrumental", "remix", "nightcore", "sped", "slowed",
             "reverb", "piano", "acoustic", "tribute", "parody", "mashup", "rendition", "remake",
-            "unplugged", "orchestral", "lofi", "8d", "guitar", "violin", "flute",
+            "unplugged", "orchestral", "lofi", "8d", "guitar", "violin", "flute", "solo",
         };
 
         private static readonly Regex Bracketed = new(@"[(\[]([^)\]]*)[)\]]", RegexOptions.Compiled);
@@ -47,6 +47,21 @@ namespace ArgonFetch.Application.Services
             string wantTitle,
             string wantArtist,
             long durationMs,
+            bool officialShelf = false) =>
+            RankMatches(candidates, wantTitle, wantArtist, durationMs, officialShelf).FirstOrDefault();
+
+        /// <summary>
+        /// Every candidate that could be the requested recording, best first.
+        /// <para>
+        /// A caller with a way to check its pick - fetching it and reading the real duration -
+        /// can walk this list instead of taking the first and hoping.
+        /// </para>
+        /// </summary>
+        public static IReadOnlyList<MatchCandidate> RankMatches(
+            IReadOnlyList<MatchCandidate> candidates,
+            string wantTitle,
+            string wantArtist,
+            long durationMs,
             bool officialShelf = false)
         {
             var want = TitleWords(wantTitle);
@@ -56,6 +71,11 @@ namespace ArgonFetch.Application.Services
             // (Remix)" must keep the remix, and that marker only survives in the bracket-keeping split.
             var asked = new HashSet<string>(MarkerWords(wantTitle), StringComparer.Ordinal);
             asked.UnionWith(MarkerWords(wantArtist));
+
+            // Title words only. Including the artist's words would let "- MEMcho Solo Ver. -"
+            // count as plainer than the group recording, because the soloist is one of the
+            // credited artists and so appears in asked.
+            var askedTitleWords = new HashSet<string>(MarkerWords(wantTitle), StringComparer.Ordinal);
 
             var titled = candidates.Where(candidate =>
                 (want.Count == 0 || TitleScore(candidate.Title, want) >= MinTitleScore) &&
@@ -80,6 +100,8 @@ namespace ArgonFetch.Application.Services
             var byArtist = titled.Where(c => ArtistMatches(c.Artist, wantArtistWords)).ToList();
             var viable = officialShelf && byArtist.Count == 0 ? titled : byArtist;
 
+            var ordered = viable.Select((candidate, index) => (candidate, index));
+
             // Duration is a tiebreaker, not a requirement. Some search backends do not report it
             // at all - YTMusicAPI returns null for every row - and filtering on it then discards
             // every candidate and resolves nothing.
@@ -87,7 +109,11 @@ namespace ArgonFetch.Application.Services
 
             if (durationMs <= 0L || timed.Count == 0)
             {
-                return viable.FirstOrDefault();
+                return ordered
+                    .OrderBy(x => ExtraWords(x.candidate.Title, askedTitleWords))
+                    .ThenBy(x => x.index)
+                    .Select(x => x.candidate)
+                    .ToList();
             }
 
             var wantSec = durationMs / 1000;
@@ -95,15 +121,56 @@ namespace ArgonFetch.Application.Services
             // YouTube Music ranks the canonical upload first. An instrumental runs to the same length
             // as the vocal take, so picking purely by the smallest duration difference let a second or
             // two of noise outrank that order; only a clearly better fit (a whole bucket) may.
-            return viable
-                .Select((candidate, index) => (candidate, index))
+            return ordered
                 .Where(x => x.candidate.DurationSec > 0 &&
                             Math.Abs(x.candidate.DurationSec - wantSec) <= DurationToleranceSec)
                 .OrderBy(x => Math.Abs(x.candidate.DurationSec - wantSec) / DurationBucketSec)
+                .ThenBy(x => ExtraWords(x.candidate.Title, askedTitleWords))
                 .ThenBy(x => x.index)
                 .Select(x => x.candidate)
-                .FirstOrDefault();
+                .ToList();
         }
+
+        /// <summary>
+        /// Candidates that match on credit alone, best first, for a caller that can verify its
+        /// pick another way.
+        /// <para>
+        /// A release is often filed under a translated name - Spotify says "REVENGE OF B" where
+        /// YouTube Music says the Japanese original - and the two titles share no words at all,
+        /// so title matching rejects every candidate and the track cannot be fetched. The credit
+        /// still matches, and a duration read from the fetched result settles which one it is,
+        /// so this is only safe for a caller that performs that check.
+        /// </para>
+        /// </summary>
+        public static IReadOnlyList<MatchCandidate> RankByCreditOnly(
+            IReadOnlyList<MatchCandidate> candidates,
+            string wantArtist)
+        {
+            var wantArtistWords = Words(RealArtist(wantArtist));
+
+            if (wantArtistWords.Count == 0)
+                return [];
+
+            var asked = new HashSet<string>(MarkerWords(wantArtist), StringComparer.Ordinal);
+
+            return candidates
+                .Where(c => ArtistMatches(c.Artist, wantArtistWords, allowScriptMismatch: false) &&
+                            !AddsRework($"{c.Title} {BracketedIn(c.Details)}", asked))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Words the candidate's title carries that nobody asked for.
+        /// <para>
+        /// Search returns the radio edit, the remaster and the twelve-inch mix alongside the
+        /// album version, all with the right title and the right credit. Where no duration is
+        /// available to separate them - and YTMusicAPI never provides one - the plainest title
+        /// is the one that was asked for. Counted with brackets kept, because that is where the
+        /// qualifier lives.
+        /// </para>
+        /// </summary>
+        internal static int ExtraWords(string candidateTitle, ISet<string> asked) =>
+            MarkerWords(candidateTitle).Count(word => !asked.Contains(word));
 
         /// <summary>
         /// True when the candidate advertises a rework the request never asked for. Asking for a
@@ -147,7 +214,12 @@ namespace ArgonFetch.Application.Services
         /// not by the artist. A source may credit several artists where YouTube credits one, so
         /// sharing a single name is enough. An unknown artist on either side cannot rule anything out.
         /// </summary>
-        internal static bool ArtistMatches(string? candidateArtist, ISet<string> wantArtist)
+        /// <param name="allowScriptMismatch">
+        /// Whether credits written in different scripts may be assumed to match. They may when a
+        /// title match already identified the recording; they may not when the credit is the only
+        /// evidence, or a karaoke label credited in one script passes for any artist in another.
+        /// </param>
+        internal static bool ArtistMatches(string? candidateArtist, ISet<string> wantArtist, bool allowScriptMismatch = true)
         {
             if (wantArtist.Count == 0) return true;
 
@@ -159,7 +231,7 @@ namespace ArgonFetch.Application.Services
             // thrown away. Skipping the check costs nothing the other filters do not already cover:
             // an upload in a different script from the artist we asked for is not what a cover or a
             // karaoke channel looks like.
-            if (HasLatin(have) != HasLatin(wantArtist)) return true;
+            if (allowScriptMismatch && HasLatin(have) != HasLatin(wantArtist)) return true;
 
             return have.Any(h => wantArtist.Any(w => NearlyEqual(h, w)));
         }

--- a/src/ArgonFetch.Tests/YouTubeMusicMatcherTests.cs
+++ b/src/ArgonFetch.Tests/YouTubeMusicMatcherTests.cs
@@ -186,6 +186,68 @@ namespace ArgonFetch.Tests
             Assert.Null(Match([]));
         }
 
+        [Fact]
+        public void BestMatch_PrefersThePlainestTitleWhenNothingElseSeparatesCandidates()
+        {
+            // Search returns the radio edit above the album version, and YTMusicAPI reports no
+            // duration for either, so without this the edit wins on search order alone.
+            var radioEdit = Candidate("One More Time (Radio Edit)", artist: "Daft Punk", durationSec: 0);
+            var albumVersion = Candidate("One More Time", artist: "Daft Punk", durationSec: 0);
+
+            var best = Match([radioEdit, albumVersion], title: "One More Time", artist: "Daft Punk", durationMs: 0);
+
+            Assert.Same(albumVersion, best);
+        }
+
+        [Fact]
+        public void BestMatch_RejectsASoloRecordingOfAGroupTrack()
+        {
+            // A solo re-recording is a different performance, and search ranks these above the
+            // group version whenever the soloist is one of the credited artists.
+            const string group = "B小町 ルビー（CV：伊駒ゆりえ）、有馬かな（CV：潘めぐみ）、MEMちょ（CV：大久保瑠美）";
+            var solo = new MatchCandidate("サインはB -MEMちょ Solo Ver.-", "B小町 MEMちょ（CV：大久保瑠美）", 0);
+
+            Assert.Null(Match([solo], title: "サインはB", artist: group, durationMs: 0, officialShelf: true));
+        }
+
+        [Fact]
+        public void RankByCreditOnly_KeepsATranslatedTitleThatSharesNoWords()
+        {
+            // Spotify says "REVENGE OF B" where YouTube Music says the Japanese original, and the
+            // two share nothing to match on. The credit is all that is left, so the caller has to
+            // confirm the pick by its length afterwards.
+            const string wanted = "B小町, ルビー(CV:伊駒ゆりえ), 有馬かな(CV:潘めぐみ), MEMちょ(CV:大久保瑠美)";
+            const string credited = "B小町 ルビー（CV：伊駒ゆりえ）、有馬かな（CV：潘めぐみ）、MEMちょ（CV：大久保瑠美）";
+
+            var translated = new MatchCandidate("Bのリベンジ", credited, 0, credited);
+
+            Assert.Null(Match([translated], title: "REVENGE OF B", artist: wanted, durationMs: 0, officialShelf: true));
+            Assert.Contains(translated, YouTubeMusicMatcher.RankByCreditOnly([translated], wanted));
+        }
+
+        [Fact]
+        public void RankByCreditOnly_StillRefusesReworksAndForeignCredits()
+        {
+            const string wanted = "B小町, ルビー(CV:伊駒ゆりえ)";
+            const string credited = "B小町 ルビー（CV：伊駒ゆりえ）";
+
+            var instrumental = new MatchCandidate("Bのリベンジ（instrumental）", credited, 0, credited);
+            var someoneElse = new MatchCandidate("Bのリベンジ", "歌っちゃ王", 0, "歌っちゃ王");
+
+            Assert.Empty(YouTubeMusicMatcher.RankByCreditOnly([instrumental, someoneElse], wanted));
+        }
+
+        [Fact]
+        public void RankByCreditOnly_RefusesToGuessWhenNoArtistWasGiven()
+        {
+            // Without a credit there is nothing left to match on at all, and returning everything
+            // would hand the caller a list of arbitrary tracks to pick from by length alone.
+            var candidate = new MatchCandidate("Anything At All", "Whoever", 0);
+
+            Assert.Empty(YouTubeMusicMatcher.RankByCreditOnly([candidate], "Unknown"));
+            Assert.Empty(YouTubeMusicMatcher.RankByCreditOnly([candidate], ""));
+        }
+
         [Theory]
         // A leading hyphen is a search operator - it tells YouTube to drop every result
         // containing the word, so the shelf came back empty for tracks named this way.

--- a/src/ArgonFetch.Tests/YouTubeMusicMatcherTests.cs
+++ b/src/ArgonFetch.Tests/YouTubeMusicMatcherTests.cs
@@ -1,0 +1,201 @@
+using ArgonFetch.Application.Services;
+
+namespace ArgonFetch.Tests
+{
+    /// <summary>
+    /// Pins the matching rules. Every bypass in the matcher is a scar from a real track that
+    /// resolved to the wrong recording or to nothing at all, and until now none of them was
+    /// held in place by anything.
+    /// </summary>
+    public class YouTubeMusicMatcherTests
+    {
+        private const long ThreeMinutesMs = 180_000;
+        private const long ThreeMinutesSec = 180;
+
+        private static MatchCandidate Candidate(
+            string title,
+            string? artist = "Rick Astley",
+            long durationSec = ThreeMinutesSec,
+            string details = "") => new(title, artist, durationSec, details);
+
+        private static MatchCandidate? Match(
+            IReadOnlyList<MatchCandidate> candidates,
+            string title = "Never Gonna Give You Up",
+            string artist = "Rick Astley",
+            long durationMs = ThreeMinutesMs,
+            bool officialShelf = false) =>
+            YouTubeMusicMatcher.BestMatch(candidates, title, artist, durationMs, officialShelf);
+
+        [Fact]
+        public void BestMatch_TakesTheRecordingThatWasAskedFor()
+        {
+            var wanted = Candidate("Never Gonna Give You Up");
+
+            Assert.Same(wanted, Match([wanted]));
+        }
+
+        [Fact]
+        public void BestMatch_ReturnsNull_RatherThanTheWrongRecording()
+        {
+            // Nothing here is the requested song. A wrong file is worse than a failed fetch,
+            // because the caller cannot tell it went wrong.
+            var result = Match([Candidate("Together Forever"), Candidate("Whenever You Need Somebody")]);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("Never Gonna Give You Up (Instrumental)")]
+        [InlineData("Never Gonna Give You Up (Karaoke Version)")]
+        [InlineData("Never Gonna Give You Up - Piano Cover")]
+        [InlineData("Never Gonna Give You Up (Nightcore)")]
+        [InlineData("Never Gonna Give You Up [Slowed + Reverb]")]
+        public void BestMatch_RejectsReworksNobodyAskedFor(string title)
+        {
+            // These carry the exact title, the exact artist and near enough the exact length,
+            // so nothing but the marker itself tells them apart from the real recording.
+            Assert.Null(Match([Candidate(title)]));
+        }
+
+        [Fact]
+        public void BestMatch_KeepsTheReworkWhenTheRequestIsForOne()
+        {
+            var remix = Candidate("Sonne (Remix)", artist: "Rammstein");
+
+            Assert.Same(remix, Match([remix], title: "Sonne (Remix)", artist: "Rammstein"));
+        }
+
+        [Fact]
+        public void BestMatch_MatchesWhenTheRequestSpellsOutAFeatureCreditAndTheCandidateDoesNot()
+        {
+            // Sources write the guest into the track name where YouTube Music puts it in
+            // brackets, which the candidate then loses to normalisation.
+            var candidate = Candidate("Stay", artist: "The Kid LAROI");
+
+            Assert.Same(candidate, Match(
+                [candidate],
+                title: "Stay (feat. Justin Bieber)",
+                artist: "The Kid LAROI"));
+        }
+
+        [Fact]
+        public void BestMatch_RejectsAnUploadCreditedToSomebodyElse()
+        {
+            // The strongest signal against a cover: someone else uploaded it.
+            Assert.Null(Match([Candidate("Never Gonna Give You Up", artist: "Some Karaoke Channel")]));
+        }
+
+        [Fact]
+        public void BestMatch_AcceptsAMismatchedCreditOnTheOfficialShelf_WhenNoCandidateCarriesTheName()
+        {
+            // The songs shelf is YouTube Music's own catalogue, so a row there is a release
+            // rather than an upload, and a differing credit is usually the same recording filed
+            // under another name. Rejecting on it would throw the release away for good.
+            var relabelled = Candidate("Never Gonna Give You Up", artist: "RickAstleyVEVO Official");
+
+            Assert.Same(relabelled, Match([relabelled], officialShelf: true));
+        }
+
+        [Fact]
+        public void BestMatch_StillPrefersTheRightCredit_WhenOneCandidateCarriesIt()
+        {
+            var wrongCredit = Candidate("Never Gonna Give You Up", artist: "Some Cover Channel");
+            var rightCredit = Candidate("Never Gonna Give You Up", artist: "Rick Astley");
+
+            Assert.Same(rightCredit, Match([wrongCredit, rightCredit], officialShelf: true));
+        }
+
+        [Fact]
+        public void BestMatch_DoesNotCompareCreditsAcrossScripts()
+        {
+            // A romanised name and the original script share no words, which used to throw away
+            // every real candidate. An upload in another script is not what a karaoke channel
+            // looks like, so the other filters carry the weight here.
+            var japanese = new MatchCandidate("Say It", "ヨルシカ", ThreeMinutesSec);
+
+            Assert.Same(japanese, Match([japanese], title: "Say It", artist: "Yorushika"));
+        }
+
+        [Fact]
+        public void BestMatch_IgnoresTheCreditWhenTheRequestHasNoRealArtist()
+        {
+            // "Unknown" reaches the matcher whenever a request carried no artist. Treating it as
+            // a credit rejects every real result.
+            var candidate = Candidate("Some Song", artist: "Whoever Uploaded It");
+
+            Assert.Same(candidate, Match([candidate], title: "Some Song", artist: "Unknown"));
+        }
+
+        [Fact]
+        public void BestMatch_PrefersTheCandidateClosestToTheAskedForLength()
+        {
+            var radioEdit = Candidate("Never Gonna Give You Up", durationSec: 200);
+            var albumVersion = Candidate("Never Gonna Give You Up", durationSec: 181);
+
+            Assert.Same(albumVersion, Match([radioEdit, albumVersion]));
+        }
+
+        [Fact]
+        public void BestMatch_KeepsSearchOrderWhenLengthsAreEquallyClose()
+        {
+            // YouTube Music ranks the canonical upload first, and a second of noise must not
+            // outrank that. Only a clearly better fit may.
+            var first = Candidate("Never Gonna Give You Up", durationSec: 182);
+            var second = Candidate("Never Gonna Give You Up", durationSec: 179);
+
+            Assert.Same(first, Match([first, second]));
+        }
+
+        [Fact]
+        public void BestMatch_IgnoresLengthWhenTheSourceReportsNone()
+        {
+            // YTMusicAPI returns no duration at all for some rows. Filtering on it then discards
+            // every candidate and the track resolves to nothing.
+            var noDuration = Candidate("Never Gonna Give You Up", durationSec: 0);
+
+            Assert.Same(noDuration, Match([noDuration]));
+        }
+
+        [Fact]
+        public void BestMatch_IgnoresLengthWhenTheRequestHasNone()
+        {
+            // Spotify's duration is scraped and can be missing; matching still has to work.
+            var candidate = Candidate("Never Gonna Give You Up", durationSec: 400);
+
+            Assert.Same(candidate, Match([candidate], durationMs: 0));
+        }
+
+        [Fact]
+        public void BestMatch_RejectsACandidateFarFromTheAskedForLength()
+        {
+            // An hour-long upload carrying the right title is a mix, not the track.
+            Assert.Null(Match([Candidate("Never Gonna Give You Up", durationSec: 3600)]));
+        }
+
+        [Fact]
+        public void BestMatch_ToleratesASpellingVariantInTheTitle()
+        {
+            var candidate = Candidate("Tobbss", artist: "Someone");
+
+            Assert.Same(candidate, Match([candidate], title: "Tobbs", artist: "Someone"));
+        }
+
+        [Fact]
+        public void BestMatch_ReturnsNullForNoCandidates()
+        {
+            Assert.Null(Match([]));
+        }
+
+        [Theory]
+        // A leading hyphen is a search operator - it tells YouTube to drop every result
+        // containing the word, so the shelf came back empty for tracks named this way.
+        [InlineData("Artist", "-topic", "Artist topic")]
+        [InlineData("Artist", "Spider-Man Theme", "Artist Spider-Man Theme")]
+        [InlineData("", "Song", "Song")]
+        [InlineData("Artist", "", "Artist")]
+        public void SearchQuery_StripsTheOperatorMeaningFromALeadingHyphen(string artist, string title, string expected)
+        {
+            Assert.Equal(expected, YouTubeMusicMatcher.SearchQuery(artist, title));
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [x] New feature (tests)

## Description
This started as a comparison against `Amonoman/YT-Music-SpotiFLAC` and turned into three real matching bugs.

**Tests first.** `YouTubeMusicMatcher` had no coverage at all, in a file where every bypass is a scar from a track that resolved wrongly. 24 cases now pin what its comments describe.

**Search reports no duration.** YTMusicAPI returns `null` for every row, so the strongest disambiguator - and the one their scorer pays 15 points for - never had data. Daft Punk''s "One More Time" resolved to the **radio edit** for that reason: right title, right credit, first in the list, four minutes instead of five. Fetching a candidate *does* report its duration, so the pick is now checked rather than trusted: fetch, compare against Spotify''s length, try the next when it does not fit, at most three.

**The plainest title wins a tie.** A radio edit, a remaster and a twelve-inch mix all carry the asked-for title and credit, and the extra words are the only thing marking them. Counted against the title alone - counting the artist too let `-MEMcho Solo Ver.-` look plainer than the group recording, because the soloist is one of the credited artists. `solo` joins the rework markers for the same reason.

**Translated titles.** Spotify says `REVENGE OF B` where YouTube Music says `Bのリベンジ`; the two share no word, so every candidate was rejected and the track could not be fetched at all. A second pass drops the title requirement and identifies the track by credit and length instead - only for a caller that performs the length check, and with the credit compared **strictly**.

## Testing
Probed against live YouTube Music before changing anything, which is where the first two bugs came from - the search rows showed `dur=null` across the board and the solo versions outranking the group recording.

End to end against a live API, measuring what actually gets served:

| track | served | expected |
|---|---|---|
| Daft Punk - One More Time | **320s** | 320s (album version; the radio edit is 236s) |
| Rick Astley - Never Gonna Give You Up | 214s | 213s |

Before this change the first row served 236s. The YouTube path is unaffected (5 audio renditions, unchanged), and 80 unit tests pass.

One hole was caught by a test rather than by me: `歌っちゃ王`, a karaoke label, passed the credit-only path because the script-mismatch bypass fires whenever the wanted artist contains a Latin letter. That bypass is safe when a title match already identified the recording and unsafe when the credit is the only evidence, so it is now disabled on that path.

## Impact
The Spotify path may now make up to three yt-dlp calls instead of one, but only when the first pick''s length disagrees with Spotify''s - the common case still costs exactly one. Measured at 5-8s end to end, unchanged from before. `InternalsVisibleTo` is added so the matcher''s steps can be tested individually.

## Issue related to PR
- Resolves #

## Additional Information
Two things this does **not** fix, both from the same investigation:
- `GetAlbumTracksAsync` throws `NullReferenceException` and `GetTrackInfoAsync` returns HTTP 400 in YTMusicAPI 1.0.7, so "pick the track from the artist''s own album" - which would rule out covers outright - is not available. Album *search* works perfectly, if that library is ever fixed or replaced.
- The translated-title path is covered by unit tests and reasoning, not by an end-to-end run: Spotify''s search is JS-rendered, so I could not obtain a real track id for one.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
