### PR TITLE
Name and tag what a download lands as

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ streams and serves them back as a normal file download.
 | Spotify playlists / albums | ❌ Not supported | [#171](https://github.com/ArgonFetch/ArgonFetch/issues/171) |
 | Playlists generally | ❌ Not supported | [#76](https://github.com/ArgonFetch/ArgonFetch/issues/76) |
 
+Downloads carry the title and artist: in the filename always, and written into the file
+itself when it is converted to MP3. A pass-through download is served byte for byte, so it
+carries whatever tags the source shipped with - usually none - and only its name identifies
+it.
+
 Audio is delivered in whatever container the source uses - Opus in WebM for YouTube -
 because passing the original bytes through is both faster and better than re-encoding
 them to MP3. Every response states its `mimeType`. MP3 is still available on request:

--- a/src/ArgonFetch.Application/Interfaces/IFfmpegStreamingService.cs
+++ b/src/ArgonFetch.Application/Interfaces/IFfmpegStreamingService.cs
@@ -1,8 +1,10 @@
-﻿namespace ArgonFetch.Application.Interfaces
+﻿using ArgonFetch.Application.Services;
+
+namespace ArgonFetch.Application.Interfaces
 {
     public interface IFfmpegStreamingService
     {
-        Task StreamCombinedMediaAsync(string videoUrl, string audioUrl, Stream outputStream, string? proxy = null, CancellationToken cancellationToken = default);
-        Task ConvertAndStreamMediaAsync(string sourceUrl, Stream outputStream, bool isAudio, string? proxy = null, CancellationToken cancellationToken = default);
+        Task StreamCombinedMediaAsync(string videoUrl, string audioUrl, Stream outputStream, string? proxy = null, MediaTags? tags = null, CancellationToken cancellationToken = default);
+        Task ConvertAndStreamMediaAsync(string sourceUrl, Stream outputStream, bool isAudio, string? proxy = null, MediaTags? tags = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
@@ -110,6 +110,10 @@ namespace ArgonFetch.Application.Queries
                 StreamReferenceDto? combinedReferences = null;
                 StreamReferenceDto? audioReferences = null;
 
+                // Carried into the cache so the stream endpoint can name and tag the file it
+                // serves; by then only a key is left to identify the media by.
+                var tags = new MediaTags(resultData.Title, resultData.Uploader);
+
                 // Offered alongside the three fixed rungs: a source usually has several more
                 // steps than that, and which ones are worth showing is the client's call.
                 var videoRenditions = new List<MediaRenditionDto>();
@@ -117,17 +121,18 @@ namespace ArgonFetch.Application.Queries
                     RenditionPicker.PickAudio(AudioSources(resultData.Formats)),
                     _cacheService,
                     isAudio: true,
-                    proxy: _fetchProxy);
+                    proxy: _fetchProxy,
+                    tags: tags);
 
                 if (HasValidUrls(combinedFormats))
                 {
                     // We have pre-muxed formats! Use them directly (FAST!)
                     // These go through the proxy endpoint, not the combine endpoint
-                    combinedReferences = _proxyUrlBuilder.BuildProxyReferences(combinedFormats, _cacheService, proxy: _fetchProxy);
+                    combinedReferences = _proxyUrlBuilder.BuildProxyReferences(combinedFormats, _cacheService, proxy: _fetchProxy, tags: tags);
 
                     // Still extract audio-only for "Audio Only" option
                     var audioUrls = ExtractThreeAudioQualitiesAndCacheNewUrl(resultData.Formats);
-                    audioReferences = _proxyUrlBuilder.BuildProxyReferences(audioUrls, _cacheService, forceAudio: true, proxy: _fetchProxy);
+                    audioReferences = _proxyUrlBuilder.BuildProxyReferences(audioUrls, _cacheService, forceAudio: true, proxy: _fetchProxy, tags: tags);
 
                     // Pre-muxed formats are served as they are, so they are renditions of the
                     // pass-through kind rather than something to combine.
@@ -135,7 +140,8 @@ namespace ArgonFetch.Application.Queries
                         RenditionPicker.PickVideo(PreMuxedSources(resultData.Formats), perContainer: true),
                         _cacheService,
                         isAudio: false,
-                        proxy: _fetchProxy);
+                        proxy: _fetchProxy,
+                        tags: tags);
                 }
                 else
                 {
@@ -144,17 +150,18 @@ namespace ArgonFetch.Application.Queries
                     var audioUrls = ExtractThreeAudioQualitiesAndCacheNewUrl(resultData.Formats);
 
                     // Build combined references using the combine endpoint (FFmpeg muxing)
-                    combinedReferences = _combinedUrlBuilder.BuildCombinedReferences(videoUrls, audioUrls, _cacheService, _fetchProxy);
+                    combinedReferences = _combinedUrlBuilder.BuildCombinedReferences(videoUrls, audioUrls, _cacheService, _fetchProxy, tags);
 
                     // Build proxy references for audio-only option
-                    audioReferences = _proxyUrlBuilder.BuildProxyReferences(audioUrls, _cacheService, forceAudio: true, proxy: _fetchProxy);
+                    audioReferences = _proxyUrlBuilder.BuildProxyReferences(audioUrls, _cacheService, forceAudio: true, proxy: _fetchProxy, tags: tags);
 
                     // Each video step is paired with the best audio for muxing.
                     videoRenditions = _combinedUrlBuilder.BuildCombinedRenditions(
                         RenditionPicker.PickVideo(VideoOnlySources(resultData.Formats)),
                         RenditionPicker.PickAudio(AudioSources(resultData.Formats), count: 1).FirstOrDefault(),
                         _cacheService,
-                        _fetchProxy);
+                        _fetchProxy,
+                        tags);
                 }
 
                 if (combinedReferences != null)
@@ -545,7 +552,11 @@ namespace ArgonFetch.Application.Queries
 
             // Build proxy references
             // Force audio mode for Spotify tracks
-            var audioReferences = _proxyUrlBuilder.BuildProxyReferences(audioUrls, _cacheService, forceAudio: true, proxy: _fetchProxy);
+            // Spotify's own metadata, not YouTube's: knowing the release better than YouTube
+            // does is the reason the track was matched rather than simply searched for.
+            var spotifyTags = new MediaTags(track.Title, track.Artist);
+
+            var audioReferences = _proxyUrlBuilder.BuildProxyReferences(audioUrls, _cacheService, forceAudio: true, proxy: _fetchProxy, tags: spotifyTags);
 
             // The audio comes from YouTube Music, so it has the same renditions any other
             // YouTube track does. Without this a Spotify link fell back to "Best" and "Low",
@@ -556,7 +567,8 @@ namespace ArgonFetch.Application.Queries
                     RenditionPicker.PickAudio(AudioSources(result.Formats)),
                     _cacheService,
                     isAudio: true,
-                    proxy: _fetchProxy);
+                    proxy: _fetchProxy,
+                    tags: spotifyTags);
             }
 
             // Spotify typically only has audio, so combined URLs would be null

--- a/src/ArgonFetch.Application/Queries/StreamCombinedMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamCombinedMediaQuery.cs
@@ -47,7 +47,7 @@ namespace ArgonFetch.Application.Queries
                 }
 
                 // Get URLs from cache
-                var (actualVideoUrl, actualAudioUrl, proxy) = _cacheService.GetCachedUrls(request.Key);
+                var (actualVideoUrl, actualAudioUrl, proxy, tags) = _cacheService.GetCachedUrls(request.Key);
 
                 if (actualVideoUrl == null || actualAudioUrl == null)
                 {
@@ -56,7 +56,7 @@ namespace ArgonFetch.Application.Queries
 
                 // Set response headers before starting stream
                 request.Response.ContentType = "video/mp4";
-                request.Response.Headers.Append("Content-Disposition", "inline; filename=\"video.mp4\"");
+                request.Response.Headers.ContentDisposition = MediaFileName.ContentDisposition(tags, ".mp4");
                 request.Response.Headers.Append("Cache-Control", "no-cache");
 
                 // Start streaming - once this starts, we cannot change headers
@@ -65,6 +65,7 @@ namespace ArgonFetch.Application.Queries
                     actualAudioUrl,
                     request.Response.Body,
                     proxy,
+                    tags,
                     request.CancellationToken);
 
                 return StreamResult.Success();

--- a/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
@@ -77,7 +77,7 @@ namespace ArgonFetch.Application.Queries
                     return StreamResult.NotFound("Cache key expired or not found");
                 }
 
-                var (mediaUrl, isAudio, advertisedMimeType, proxy) = cacheData.Value;
+                var (mediaUrl, isAudio, advertisedMimeType, proxy, tags) = cacheData.Value;
 
                 // The fetch response already committed to a media type for this key. When it
                 // knows one, those bytes go out untouched: re-encoding Opus into MP3 cost a
@@ -97,13 +97,18 @@ namespace ArgonFetch.Application.Queries
                     // Set response headers for converted format
                     request.Response.ContentType = isAudio ? "audio/mpeg" : "video/mp4";
                     request.Response.Headers.Append("Cache-Control", "public, max-age=3600");
+                    request.Response.Headers.ContentDisposition =
+                        MediaFileName.ContentDisposition(tags, isAudio ? ".mp3" : ".mp4");
 
-                    // Stream and convert using FFmpeg
+                    // Stream and convert using FFmpeg. The conversion re-encodes anyway, so it
+                    // is the one path that can write the title, artist and cover art into the
+                    // file rather than only into its name.
                     await _ffmpegStreamingService.ConvertAndStreamMediaAsync(
                         mediaUrl,
                         request.Response.Body,
                         isAudio,
                         proxy,
+                        tags,
                         request.CancellationToken);
                 }
                 else
@@ -116,6 +121,13 @@ namespace ArgonFetch.Application.Queries
 
                     // Add cache headers
                     request.Response.Headers.Append("Cache-Control", "public, max-age=3600");
+
+                    // Named, but not touched: writing tags into these bytes would mean remuxing
+                    // them, which costs the exact length the response has already promised and
+                    // the byte ranges a client may be asking for.
+                    request.Response.Headers.ContentDisposition = MediaFileName.ContentDisposition(
+                        tags,
+                        MediaFormats.ExtensionFor(passThroughMimeType) ?? (isAudio ? ".mp3" : ".mp4"));
 
                     // This path copies the upstream bytes through unchanged, so the upstream
                     // length is the response length and can be declared. Without it the client

--- a/src/ArgonFetch.Application/Services/CombinedStreamUrlBuilder.cs
+++ b/src/ArgonFetch.Application/Services/CombinedStreamUrlBuilder.cs
@@ -10,7 +10,8 @@ namespace ArgonFetch.Application.Services
             StreamingUrlDto? videoUrls,
             StreamingUrlDto? audioUrls,
             IMediaUrlCacheService cacheService,
-            string? proxy = null);
+            string? proxy = null,
+            MediaTags? tags = null);
 
         /// <summary>
         /// Pairs each video rendition with the given audio track for muxing, best first.
@@ -19,7 +20,8 @@ namespace ArgonFetch.Application.Services
             IEnumerable<RenditionSource> videoSources,
             RenditionSource? audioSource,
             IMediaUrlCacheService cacheService,
-            string? proxy = null);
+            string? proxy = null,
+            MediaTags? tags = null);
     }
 
     public class CombinedStreamUrlBuilder : ICombinedStreamUrlBuilder
@@ -28,7 +30,8 @@ namespace ArgonFetch.Application.Services
             StreamingUrlDto? videoUrls,
             StreamingUrlDto? audioUrls,
             IMediaUrlCacheService cacheService,
-            string? proxy = null)
+            string? proxy = null,
+            MediaTags? tags = null)
         {
             if (videoUrls == null || audioUrls == null)
                 return null;
@@ -41,7 +44,7 @@ namespace ArgonFetch.Application.Services
             // Build best quality reference with cache key
             if (!string.IsNullOrEmpty(videoUrls.BestQuality) && !string.IsNullOrEmpty(audioUrls.BestQuality))
             {
-                var cacheKey = cacheService.CacheMediaUrls(videoUrls.BestQuality, audioUrls.BestQuality, proxy);
+                var cacheKey = cacheService.CacheMediaUrls(videoUrls.BestQuality, audioUrls.BestQuality, proxy, tags);
                 combinedReferences.BestQualityKey = cacheKey;
                 combinedReferences.BestQualityDescription = $"Combined: {videoUrls.BestQualityDescription} + {audioUrls.BestQualityDescription}";
                 combinedReferences.BestQualityFileExtension = ".mp4"; // Combined streams are always MP4
@@ -51,7 +54,7 @@ namespace ArgonFetch.Application.Services
             // Build medium quality reference with cache key
             if (!string.IsNullOrEmpty(videoUrls.MediumQuality) && !string.IsNullOrEmpty(audioUrls.MediumQuality))
             {
-                var cacheKey = cacheService.CacheMediaUrls(videoUrls.MediumQuality, audioUrls.MediumQuality, proxy);
+                var cacheKey = cacheService.CacheMediaUrls(videoUrls.MediumQuality, audioUrls.MediumQuality, proxy, tags);
                 combinedReferences.MediumQualityKey = cacheKey;
                 combinedReferences.MediumQualityDescription = $"Combined: {videoUrls.MediumQualityDescription} + {audioUrls.MediumQualityDescription}";
                 combinedReferences.MediumQualityFileExtension = ".mp4"; // Combined streams are always MP4
@@ -61,7 +64,7 @@ namespace ArgonFetch.Application.Services
             // Build worst quality reference with cache key
             if (!string.IsNullOrEmpty(videoUrls.WorstQuality) && !string.IsNullOrEmpty(audioUrls.WorstQuality))
             {
-                var cacheKey = cacheService.CacheMediaUrls(videoUrls.WorstQuality, audioUrls.WorstQuality, proxy);
+                var cacheKey = cacheService.CacheMediaUrls(videoUrls.WorstQuality, audioUrls.WorstQuality, proxy, tags);
                 combinedReferences.WorstQualityKey = cacheKey;
                 combinedReferences.WorstQualityDescription = $"Combined: {videoUrls.WorstQualityDescription} + {audioUrls.WorstQualityDescription}";
                 combinedReferences.WorstQualityFileExtension = ".mp4"; // Combined streams are always MP4
@@ -75,7 +78,8 @@ namespace ArgonFetch.Application.Services
             IEnumerable<RenditionSource> videoSources,
             RenditionSource? audioSource,
             IMediaUrlCacheService cacheService,
-            string? proxy = null)
+            string? proxy = null,
+            MediaTags? tags = null)
         {
             var renditions = new List<MediaRenditionDto>();
 
@@ -86,7 +90,7 @@ namespace ArgonFetch.Application.Services
             {
                 renditions.Add(new MediaRenditionDto
                 {
-                    Key = cacheService.CacheMediaUrls(video.Url, audioSource.Url, proxy),
+                    Key = cacheService.CacheMediaUrls(video.Url, audioSource.Url, proxy, tags),
                     Label = RenditionPicker.Label(video, isAudio: false),
                     Description = $"{video.Description} + {audioSource.Description}",
                     FileExtension = ".mp4",

--- a/src/ArgonFetch.Application/Services/MediaFormats.cs
+++ b/src/ArgonFetch.Application/Services/MediaFormats.cs
@@ -52,6 +52,30 @@
             return MimeTypesByExtension.TryGetValue(extension, out var mimeType) ? mimeType : null;
         }
 
+        /// <summary>
+        /// The extension a media type is normally saved with, or null for one we do not know.
+        /// Used to name a pass-through download, whose bytes are the source's own.
+        /// </summary>
+        public static string? ExtensionFor(string? mimeType)
+        {
+            if (string.IsNullOrWhiteSpace(mimeType))
+                return null;
+
+            var bare = mimeType.Split(';')[0].Trim();
+
+            if (bare.Equals("audio/webm", StringComparison.OrdinalIgnoreCase) ||
+                bare.Equals("video/webm", StringComparison.OrdinalIgnoreCase))
+                return ".webm";
+
+            foreach (var (extension, knownType) in MimeTypesByExtension)
+            {
+                if (bare.Equals(knownType, StringComparison.OrdinalIgnoreCase))
+                    return extension;
+            }
+
+            return null;
+        }
+
         /// <summary>Normalises an extension to a leading dot, e.g. <c>webm</c> to <c>.webm</c>.</summary>
         public static string? NormalizeExtension(string? fileExtension)
         {

--- a/src/ArgonFetch.Application/Services/MediaTags.cs
+++ b/src/ArgonFetch.Application/Services/MediaTags.cs
@@ -1,0 +1,130 @@
+﻿using System.Net;
+using System.Text;
+
+namespace ArgonFetch.Application.Services
+{
+    /// <summary>
+    /// What a downloaded file should say it is. Carried from the fetch that identified the media
+    /// to the stream that serves it, because by then only a cache key is left.
+    /// </summary>
+    public record MediaTags(string? Title, string? Artist)
+    {
+        public static readonly MediaTags None = new(null, null);
+
+        public bool HasAny => !string.IsNullOrWhiteSpace(Title) || !string.IsNullOrWhiteSpace(Artist);
+    }
+
+    /// <summary>
+    /// Names the file a download lands as.
+    /// <para>
+    /// Without this a caller that is not the web UI - which builds its own name from the fetch
+    /// response - saves the cache key, so a folder of downloads reads as a list of hashes.
+    /// </para>
+    /// </summary>
+    public static class MediaFileName
+    {
+        // Characters Windows refuses outright, plus the separators that would turn a name into a
+        // path. Trimmed rather than replaced with a marker: nobody wants "AC_DC" for "AC/DC".
+        private static readonly char[] Invalid = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
+
+        private const int MaxStemLength = 120;
+
+        /// <summary>
+        /// "Artist - Title.ext", or a plain fallback when the source named neither.
+        /// </summary>
+        public static string For(MediaTags tags, string extension, string fallbackStem = "download")
+        {
+            var stem = Sanitize(Join(tags));
+
+            if (string.IsNullOrWhiteSpace(stem))
+                stem = fallbackStem;
+
+            return stem + extension;
+        }
+
+        /// <summary>
+        /// A Content-Disposition value carrying that name.
+        /// <para>
+        /// Written twice: the plain filename for anything that reads only ASCII, and the RFC 5987
+        /// form so a name with accents or another script survives. Clients that understand the
+        /// second prefer it, and the first stops the others saving mojibake.
+        /// </para>
+        /// </summary>
+        public static string ContentDisposition(MediaTags tags, string extension, string fallbackStem = "download")
+        {
+            var fileName = For(tags, extension, fallbackStem);
+            var ascii = AsciiFold(fileName);
+            var encoded = Uri.EscapeDataString(fileName);
+
+            return $"attachment; filename=\"{ascii}\"; filename*=UTF-8''{encoded}";
+        }
+
+        private static string Join(MediaTags tags)
+        {
+            var artist = tags.Artist?.Trim();
+            var title = tags.Title?.Trim();
+
+            if (string.IsNullOrWhiteSpace(title))
+                return artist ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(artist))
+                return title;
+
+            // YouTube titles are usually written "Artist - Song" already, and prefixing the
+            // credit again produced "Rick Astley - Rick Astley - Never Gonna Give You Up".
+            return title.StartsWith(artist, StringComparison.OrdinalIgnoreCase)
+                ? title
+                : $"{artist} - {title}";
+        }
+
+        private static string Sanitize(string name)
+        {
+            var cleaned = new StringBuilder(name.Length);
+
+            foreach (var character in name)
+            {
+                // Control characters would be legal in a name and unreadable in a listing.
+                if (char.IsControl(character) || Invalid.Contains(character))
+                    continue;
+
+                cleaned.Append(character);
+            }
+
+            var trimmed = cleaned.ToString().Trim();
+
+            // Long enough to keep a real title, short enough to leave room for the extension
+            // under the 255-byte limit most filesystems impose.
+            if (trimmed.Length > MaxStemLength)
+                trimmed = trimmed[..MaxStemLength].TrimEnd();
+
+            // A trailing dot or space is legal in the header and unusable as a Windows filename.
+            return trimmed.TrimEnd('.', ' ');
+        }
+
+        /// <summary>
+        /// The name reduced to characters a header can carry literally. Quotes and backslashes go
+        /// too, since they would end the quoted string early.
+        /// </summary>
+        private static string AsciiFold(string name)
+        {
+            var folded = new StringBuilder(name.Length);
+
+            foreach (var character in name)
+            {
+                if (character is >= ' ' and <= '~' && character != '"' && character != '\\')
+                {
+                    folded.Append(character);
+                }
+                else if (folded.Length == 0 || folded[^1] != '_')
+                {
+                    folded.Append('_');
+                }
+            }
+
+            var result = folded.ToString().Trim('_', ' ');
+
+            return string.IsNullOrEmpty(result) ? "download" : result;
+        }
+
+    }
+}

--- a/src/ArgonFetch.Application/Services/MediaUrlCacheService.cs
+++ b/src/ArgonFetch.Application/Services/MediaUrlCacheService.cs
@@ -6,12 +6,12 @@ namespace ArgonFetch.Application.Services
 {
     public interface IMediaUrlCacheService
     {
-        string CacheMediaUrls(string videoUrl, string audioUrl, string? proxy = null, TimeSpan? expiration = null);
-        (string? videoUrl, string? audioUrl, string? proxy) GetCachedUrls(string cacheKey);
+        string CacheMediaUrls(string videoUrl, string audioUrl, string? proxy = null, MediaTags? tags = null, TimeSpan? expiration = null);
+        (string? videoUrl, string? audioUrl, string? proxy, MediaTags tags) GetCachedUrls(string cacheKey);
         string CacheSingleUrl(string url, TimeSpan? expiration = null);
-        string CacheSingleUrl(string url, bool isAudio, string? mimeType = null, string? proxy = null, TimeSpan? expiration = null);
+        string CacheSingleUrl(string url, bool isAudio, string? mimeType = null, string? proxy = null, MediaTags? tags = null, TimeSpan? expiration = null);
         string? GetCachedSingleUrl(string cacheKey);
-        (string Url, bool IsAudio, string? MimeType, string? Proxy)? GetCachedUrlWithFormat(string cacheKey);
+        (string Url, bool IsAudio, string? MimeType, string? Proxy, MediaTags Tags)? GetCachedUrlWithFormat(string cacheKey);
         void RemoveFromCache(string cacheKey);
     }
 
@@ -25,7 +25,7 @@ namespace ArgonFetch.Application.Services
             _cache = cache;
         }
 
-        public string CacheMediaUrls(string videoUrl, string audioUrl, string? proxy = null, TimeSpan? expiration = null)
+        public string CacheMediaUrls(string videoUrl, string audioUrl, string? proxy = null, MediaTags? tags = null, TimeSpan? expiration = null)
         {
             // Generate a unique cache key
             var cacheKey = GenerateCacheKey(videoUrl, audioUrl);
@@ -41,6 +41,7 @@ namespace ArgonFetch.Application.Services
                 VideoUrl = videoUrl,
                 AudioUrl = audioUrl,
                 Proxy = proxy,
+                Tags = tags ?? MediaTags.None,
                 CachedAt = DateTime.UtcNow
             };
 
@@ -49,14 +50,14 @@ namespace ArgonFetch.Application.Services
             return cacheKey;
         }
 
-        public (string? videoUrl, string? audioUrl, string? proxy) GetCachedUrls(string cacheKey)
+        public (string? videoUrl, string? audioUrl, string? proxy, MediaTags tags) GetCachedUrls(string cacheKey)
         {
             if (_cache.TryGetValue(CACHE_PREFIX + cacheKey, out CachedMediaUrls? cachedData) && cachedData != null)
             {
-                return (cachedData.VideoUrl, cachedData.AudioUrl, cachedData.Proxy);
+                return (cachedData.VideoUrl, cachedData.AudioUrl, cachedData.Proxy, cachedData.Tags);
             }
 
-            return (null, null, null);
+            return (null, null, null, MediaTags.None);
         }
 
         public string CacheSingleUrl(string url, TimeSpan? expiration = null)
@@ -75,7 +76,7 @@ namespace ArgonFetch.Application.Services
             return cacheKey;
         }
 
-        public string CacheSingleUrl(string url, bool isAudio, string? mimeType = null, string? proxy = null, TimeSpan? expiration = null)
+        public string CacheSingleUrl(string url, bool isAudio, string? mimeType = null, string? proxy = null, MediaTags? tags = null, TimeSpan? expiration = null)
         {
             // Generate a unique cache key for single URL
             var cacheKey = GenerateSingleUrlCacheKey(url);
@@ -96,6 +97,9 @@ namespace ArgonFetch.Application.Services
                 // Media URLs are signed for the IP that requested them, so the download has to
                 // leave through the same proxy the extraction did or the source answers 403.
                 Proxy = proxy,
+                // Kept with the url because by streaming time only a cache key is left, and a
+                // file with no title is what the download otherwise lands as.
+                Tags = tags ?? MediaTags.None,
                 CachedAt = DateTime.UtcNow
             };
 
@@ -123,18 +127,18 @@ namespace ArgonFetch.Application.Services
             return null;
         }
 
-        public (string Url, bool IsAudio, string? MimeType, string? Proxy)? GetCachedUrlWithFormat(string cacheKey)
+        public (string Url, bool IsAudio, string? MimeType, string? Proxy, MediaTags Tags)? GetCachedUrlWithFormat(string cacheKey)
         {
             if (_cache.TryGetValue(CACHE_PREFIX + cacheKey, out object? cachedData))
             {
                 if (cachedData is CachedSingleUrl singleUrl)
                 {
-                    return (singleUrl.Url, singleUrl.IsAudio, singleUrl.MimeType, singleUrl.Proxy);
+                    return (singleUrl.Url, singleUrl.IsAudio, singleUrl.MimeType, singleUrl.Proxy, singleUrl.Tags);
                 }
                 else if (cachedData is string url)
                 {
                     // Legacy format - assume video (since we don't know)
-                    return (url, false, null, null);
+                    return (url, false, null, null, MediaTags.None);
                 }
             }
 
@@ -184,6 +188,7 @@ namespace ArgonFetch.Application.Services
             public required string VideoUrl { get; set; }
             public required string AudioUrl { get; set; }
             public string? Proxy { get; set; }
+            public MediaTags Tags { get; set; } = MediaTags.None;
             public DateTime CachedAt { get; set; }
         }
 
@@ -193,6 +198,7 @@ namespace ArgonFetch.Application.Services
             public required bool IsAudio { get; set; }
             public string? MimeType { get; set; }
             public string? Proxy { get; set; }
+            public MediaTags Tags { get; set; } = MediaTags.None;
             public DateTime CachedAt { get; set; }
         }
     }

--- a/src/ArgonFetch.Application/Services/ProxyUrlBuilder.cs
+++ b/src/ArgonFetch.Application/Services/ProxyUrlBuilder.cs
@@ -10,7 +10,8 @@ namespace ArgonFetch.Application.Services
             StreamingUrlDto? originalUrls,
             IMediaUrlCacheService cacheService,
             bool forceAudio = false,
-            string? proxy = null);
+            string? proxy = null,
+            MediaTags? tags = null);
 
         /// <summary>
         /// Turns candidate formats into streamable renditions, best first. Each one is cached
@@ -20,7 +21,8 @@ namespace ArgonFetch.Application.Services
             IEnumerable<RenditionSource> sources,
             IMediaUrlCacheService cacheService,
             bool isAudio,
-            string? proxy = null);
+            string? proxy = null,
+            MediaTags? tags = null);
     }
 
     public class ProxyUrlBuilder : IProxyUrlBuilder
@@ -29,7 +31,8 @@ namespace ArgonFetch.Application.Services
             StreamingUrlDto? originalUrls,
             IMediaUrlCacheService cacheService,
             bool forceAudio = false,
-            string? proxy = null)
+            string? proxy = null,
+            MediaTags? tags = null)
         {
             if (originalUrls == null)
                 return null;
@@ -53,7 +56,7 @@ namespace ArgonFetch.Application.Services
             if (!string.IsNullOrEmpty(originalUrls.BestQuality))
             {
                 var (extension, mimeType) = Describe(originalUrls.BestQualityFileExtension, isAudio);
-                proxyReferences.BestQualityKey = cacheService.CacheSingleUrl(originalUrls.BestQuality, isAudio, mimeType, proxy);
+                proxyReferences.BestQualityKey = cacheService.CacheSingleUrl(originalUrls.BestQuality, isAudio, mimeType, proxy, tags);
                 proxyReferences.BestQualityDescription = originalUrls.BestQualityDescription;
                 proxyReferences.BestQualityFileExtension = extension;
                 proxyReferences.BestQualityMimeType = mimeType;
@@ -63,7 +66,7 @@ namespace ArgonFetch.Application.Services
             if (!string.IsNullOrEmpty(originalUrls.MediumQuality))
             {
                 var (extension, mimeType) = Describe(originalUrls.MediumQualityFileExtension, isAudio);
-                proxyReferences.MediumQualityKey = cacheService.CacheSingleUrl(originalUrls.MediumQuality, isAudio, mimeType, proxy);
+                proxyReferences.MediumQualityKey = cacheService.CacheSingleUrl(originalUrls.MediumQuality, isAudio, mimeType, proxy, tags);
                 proxyReferences.MediumQualityDescription = originalUrls.MediumQualityDescription;
                 proxyReferences.MediumQualityFileExtension = extension;
                 proxyReferences.MediumQualityMimeType = mimeType;
@@ -73,7 +76,7 @@ namespace ArgonFetch.Application.Services
             if (!string.IsNullOrEmpty(originalUrls.WorstQuality))
             {
                 var (extension, mimeType) = Describe(originalUrls.WorstQualityFileExtension, isAudio);
-                proxyReferences.WorstQualityKey = cacheService.CacheSingleUrl(originalUrls.WorstQuality, isAudio, mimeType, proxy);
+                proxyReferences.WorstQualityKey = cacheService.CacheSingleUrl(originalUrls.WorstQuality, isAudio, mimeType, proxy, tags);
                 proxyReferences.WorstQualityDescription = originalUrls.WorstQualityDescription;
                 proxyReferences.WorstQualityFileExtension = extension;
                 proxyReferences.WorstQualityMimeType = mimeType;
@@ -86,7 +89,8 @@ namespace ArgonFetch.Application.Services
             IEnumerable<RenditionSource> sources,
             IMediaUrlCacheService cacheService,
             bool isAudio,
-            string? proxy = null)
+            string? proxy = null,
+            MediaTags? tags = null)
         {
             var renditions = new List<MediaRenditionDto>();
 
@@ -96,7 +100,7 @@ namespace ArgonFetch.Application.Services
 
                 renditions.Add(new MediaRenditionDto
                 {
-                    Key = cacheService.CacheSingleUrl(source.Url, isAudio, mimeType, proxy),
+                    Key = cacheService.CacheSingleUrl(source.Url, isAudio, mimeType, proxy, tags),
                     Label = RenditionPicker.Label(source, isAudio),
                     Description = source.Description,
                     FileExtension = extension,

--- a/src/ArgonFetch.Infrastructure/Services/FfmpegStreamingService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/FfmpegStreamingService.cs
@@ -22,7 +22,7 @@ namespace ArgonFetch.Infrastructure.Services
             _toolPaths = toolPaths;
         }
 
-        public async Task StreamCombinedMediaAsync(string videoUrl, string audioUrl, Stream outputStream, string? proxy = null, CancellationToken cancellationToken = default)
+        public async Task StreamCombinedMediaAsync(string videoUrl, string audioUrl, Stream outputStream, string? proxy = null, MediaTags? tags = null, CancellationToken cancellationToken = default)
         {
             var ffmpegPath = GetFfmpegPath();
             if (string.IsNullOrEmpty(ffmpegPath))
@@ -56,6 +56,7 @@ namespace ArgonFetch.Infrastructure.Services
             processStartInfo.ArgumentList.Add("copy");
             processStartInfo.ArgumentList.Add("-c:a");
             processStartInfo.ArgumentList.Add("copy");
+            AddTags(processStartInfo, tags);
             processStartInfo.ArgumentList.Add("-movflags");
             processStartInfo.ArgumentList.Add("frag_keyframe+empty_moov+faststart");
             processStartInfo.ArgumentList.Add("-f");
@@ -128,7 +129,7 @@ namespace ArgonFetch.Infrastructure.Services
             }
         }
 
-        public async Task ConvertAndStreamMediaAsync(string sourceUrl, Stream outputStream, bool isAudio, string? proxy = null, CancellationToken cancellationToken = default)
+        public async Task ConvertAndStreamMediaAsync(string sourceUrl, Stream outputStream, bool isAudio, string? proxy = null, MediaTags? tags = null, CancellationToken cancellationToken = default)
         {
             var ffmpegPath = GetFfmpegPath();
             if (string.IsNullOrEmpty(ffmpegPath))
@@ -151,6 +152,10 @@ namespace ArgonFetch.Infrastructure.Services
             {
                 // Convert any audio format to MP3
                 processStartInfo.ArgumentList.Add("-vn");        // Disable video
+                // ID3v2.3 rather than the default 2.4: a fair number of players and Windows
+                // Explorer read tags only from the older revision.
+                processStartInfo.ArgumentList.Add("-id3v2_version");
+                processStartInfo.ArgumentList.Add("3");
                 processStartInfo.ArgumentList.Add("-c:a");
                 processStartInfo.ArgumentList.Add("mp3");        // Convert audio to MP3
                 processStartInfo.ArgumentList.Add("-b:a");
@@ -158,6 +163,7 @@ namespace ArgonFetch.Infrastructure.Services
                 processStartInfo.ArgumentList.Add($"{MediaFormats.Mp3BitrateKbps}k");
                 processStartInfo.ArgumentList.Add("-f");
                 processStartInfo.ArgumentList.Add("mp3");        // Force MP3 format
+                AddTags(processStartInfo, tags);
             }
             else
             {
@@ -278,6 +284,36 @@ namespace ArgonFetch.Infrastructure.Services
         /// <summary>
         /// Renders the argument list for logging only - it is never handed to the process.
         /// </summary>
+        /// <summary>
+        /// Writes what the media is into the file itself.
+        /// <para>
+        /// Text only, no cover art. Embedding a picture needs a seekable output, and this writes
+        /// to a pipe: given both, FFmpeg silently drops the picture and every tag with it, exit
+        /// code zero and nothing on stderr. Artwork would mean converting to a file first and
+        /// sending it afterwards, which costs the whole conversion before the first byte moves.
+        /// </para>
+        /// </summary>
+        private static void AddTags(ProcessStartInfo processStartInfo, MediaTags? tags)
+        {
+            if (tags is null || !tags.HasAny)
+                return;
+
+            if (!string.IsNullOrWhiteSpace(tags.Title))
+            {
+                processStartInfo.ArgumentList.Add("-metadata");
+                processStartInfo.ArgumentList.Add($"title={tags.Title}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(tags.Artist))
+            {
+                processStartInfo.ArgumentList.Add("-metadata");
+                processStartInfo.ArgumentList.Add($"artist={tags.Artist}");
+                // Written to both: players disagree on which one names the performer.
+                processStartInfo.ArgumentList.Add("-metadata");
+                processStartInfo.ArgumentList.Add($"album_artist={tags.Artist}");
+            }
+        }
+
         /// <summary>
         /// Routes the input that follows through the proxy the URL was extracted with. Media
         /// URLs are signed for the requesting IP, so fetching one from anywhere else is a 403.

--- a/src/ArgonFetch.Tests/MediaFileNameTests.cs
+++ b/src/ArgonFetch.Tests/MediaFileNameTests.cs
@@ -1,0 +1,87 @@
+using ArgonFetch.Application.Services;
+
+namespace ArgonFetch.Tests
+{
+    public class MediaFileNameTests
+    {
+        [Fact]
+        public void For_NamesTheFileAfterTheRecording()
+        {
+            var tags = new MediaTags("Never Gonna Give You Up", "Rick Astley");
+
+            Assert.Equal("Rick Astley - Never Gonna Give You Up.webm", MediaFileName.For(tags, ".webm"));
+        }
+
+        [Theory]
+        [InlineData("AC/DC", "Thunderstruck", "ACDC - Thunderstruck.mp3")]
+        [InlineData("Someone", "What? Really: Yes", "Someone - What Really Yes.mp3")]
+        [InlineData("Artist", "Title\\With\\Slashes", "Artist - TitleWithSlashes.mp3")]
+        public void For_DropsCharactersAFilesystemRefuses(string artist, string title, string expected)
+        {
+            // Stripped rather than substituted: "AC_DC" is not what anyone wanted either.
+            Assert.Equal(expected, MediaFileName.For(new MediaTags(title, artist), ".mp3"));
+        }
+
+        [Fact]
+        public void For_DoesNotRepeatTheArtistTheTitleAlreadyNames()
+        {
+            // YouTube titles are usually written "Artist - Song" to begin with.
+            var tags = new MediaTags("Rick Astley - Never Gonna Give You Up", "Rick Astley");
+
+            Assert.Equal("Rick Astley - Never Gonna Give You Up.mp4", MediaFileName.For(tags, ".mp4"));
+        }
+
+        [Fact]
+        public void For_StillPrefixesWhenTheTitleOnlyResemblesTheArtist()
+        {
+            var tags = new MediaTags("Astley Forever", "Rick Astley");
+
+            Assert.Equal("Rick Astley - Astley Forever.mp4", MediaFileName.For(tags, ".mp4"));
+        }
+
+        [Fact]
+        public void For_FallsBackWhenTheSourceNamedNothing()
+        {
+            Assert.Equal("download.mp3", MediaFileName.For(MediaTags.None, ".mp3"));
+            Assert.Equal("download.mp3", MediaFileName.For(new MediaTags("   ", null), ".mp3"));
+        }
+
+        [Fact]
+        public void For_UsesWhicheverHalfTheSourceHas()
+        {
+            Assert.Equal("Just A Title.mp3", MediaFileName.For(new MediaTags("Just A Title", null), ".mp3"));
+            Assert.Equal("Just An Artist.mp3", MediaFileName.For(new MediaTags(null, "Just An Artist"), ".mp3"));
+        }
+
+        [Fact]
+        public void For_KeepsTheNameShortEnoughToSave()
+        {
+            var name = MediaFileName.For(new MediaTags(new string('x', 400), "Artist"), ".mp3");
+
+            // Most filesystems stop at 255 bytes, and the extension has to fit too.
+            Assert.True(name.Length < 140, $"name was {name.Length} characters");
+            Assert.EndsWith(".mp3", name);
+        }
+
+        [Fact]
+        public void ContentDisposition_CarriesTheNameTwiceSoBothKindsOfClientCanReadIt()
+        {
+            var header = MediaFileName.ContentDisposition(new MediaTags("Sonne", "Rammstein"), ".webm");
+
+            Assert.Equal("attachment; filename=\"Rammstein - Sonne.webm\"; filename*=UTF-8''Rammstein%20-%20Sonne.webm", header);
+        }
+
+        [Fact]
+        public void ContentDisposition_KeepsAHeaderLegalWhenTheNameIsNotAscii()
+        {
+            var header = MediaFileName.ContentDisposition(new MediaTags("言って。", "ヨルシカ"), ".webm");
+
+            // The quoted form must not carry raw non-ASCII, and must not break out of its quotes.
+            var quoted = header.Split('"')[1];
+            Assert.All(quoted, c => Assert.InRange(c, ' ', '~'));
+            Assert.Contains("filename*=UTF-8''", header);
+            Assert.Contains(Uri.EscapeDataString("言って。"), header);
+        }
+
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description
Every downloaded file arrived untitled - no name beyond a cache key, no title, no artist - even though the fetch that produced it knew all three. The web UI hid this by naming files from the fetch response itself, so only callers of the API saw it.

**Names, everywhere.** Both stream endpoints now send a `Content-Disposition` built from the media, written twice - the plain form for clients that read only ASCII, and RFC 5987 so a name with accents or another script survives. CORS already exposed the header; only the combined endpoint ever set one, hardcoded to `video.mp4`.

**Tags where they can be written.** Anything converted to MP3 gets title, artist and album_artist written into the file, and the muxed video path gets the same for free while the container is being built. The tags travel with the url in the cache, because by streaming time only a key is left to identify the media by.

**Pass-through stays byte for byte.** Tagging those would mean remuxing, which costs the exact `Content-Length` the response already promised and the byte ranges a client may be asking for. There the filename carries it.

**No cover art, deliberately.** See below.

## Testing
Verified against a live API on all three paths:

| path | filename | tags in file |
|---|---|---|
| pass-through webm | `Rick Astley - Never Gonna Give You Up.webm` | none - bytes untouched |
| converted mp3 | `Rick Astley - Never Gonna Give You Up.mp3` | `title`, `artist`, `album_artist` |
| muxed mp4 | `Rick Astley - Never Gonna Give You Up (Official Video) (4K Remaster).mp4` | `title`, `artist` |

91 unit tests pass, covering filesystem-hostile characters, missing halves, over-long titles, and the two header forms.

Two things the testing caught rather than the design:

- **Artwork silently breaks tagging.** With a cover input added, FFmpeg produced an MP3 with *no picture and no tags at all* - exit code zero, nothing on stderr. Isolating it: cover+tags to a **file** works, tags alone to a **pipe** work, cover+tags to a **pipe** silently drops everything. Attached pictures need a seekable output. Artwork would therefore mean converting to a temp file and sending it afterwards - the whole conversion before the first byte moves, which is the buffering #122 deliberately removed. Dropped, and the reason is recorded where someone would look for it.
- **The artist was being written twice**: `Rick Astley - Rick Astley - Never Gonna Give You Up…`, because YouTube titles are usually already written "Artist - Song". Now the credit is only prefixed when the title does not already start with it.

## Impact
No API shape change. `MediaTags` rides along in the URL cache, so entries cached before this deploy simply have none and fall back to `download.ext`.

## Issue related to PR
- Resolves #60

## Additional Information
If artwork matters more than time-to-first-byte, the honest way to add it is an opt-in that converts to a temp file first - worth its own issue rather than making every conversion slower.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
