### PR TITLE
Search YouTube Music with a client that reports durations and albums

### DIFF
--- a/src/ArgonFetch.API/ArgonFetch.API.csproj
+++ b/src/ArgonFetch.API/ArgonFetch.API.csproj
@@ -26,7 +26,6 @@
 	<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.1.2" />
 	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.2" />
 	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.2" />
-	<PackageReference Include="YTMusicAPI" Version="1.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -93,7 +93,10 @@ builder.Services.AddScoped<ArgonFetch.Application.Services.ISpotifyMetadataServi
                            ArgonFetch.Application.Services.SpotifyMetadataService>();
 
 // Register YoutubeMusicAPI and YoutubeDL
-builder.Services.AddScoped<YTMusicAPI.SearchClient>();
+// Search and metadata only. Its streaming endpoints need a PoToken and answer 403 to IPs
+// that look like VPNs, which is exactly what a rotated proxy looks like; yt-dlp fetches the
+// media instead, as it always has.
+builder.Services.AddSingleton<YouTubeMusicAPI.Client.YouTubeMusicClient>();
 builder.Services.AddScoped(sp =>
 {
     var toolPaths = sp.GetRequiredService<ArgonFetch.Application.Services.IToolPaths>();

--- a/src/ArgonFetch.Application/ArgonFetch.Application.csproj
+++ b/src/ArgonFetch.Application/ArgonFetch.Application.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="YoutubeDLSharp" Version="1.2.0" />
-    <PackageReference Include="YTMusicAPI" Version="1.0.7" />
+    <PackageReference Include="YouTubeMusicAPI" Version="3.0.10" />
   </ItemGroup>
 
 </Project>

--- a/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Caching.Memory;
 using YoutubeDLSharp;
 using YoutubeDLSharp.Metadata;
 using YoutubeDLSharp.Options;
+using YouTubeMusicAPI.Client;
+using YouTubeMusicAPI.Models.Search;
 
 namespace ArgonFetch.Application.Queries
 {
@@ -25,7 +27,7 @@ namespace ArgonFetch.Application.Queries
     {
         private readonly YoutubeDL _youtubeDL;
         private readonly ISpotifyMetadataService _spotifyMetadataService;
-        private readonly YTMusicAPI.SearchClient _ytmSearchClient;
+        private readonly YouTubeMusicClient _ytmClient;
         private readonly TikTokDllFetcherService _tikTokDllFetcherService;
         private readonly IMemoryCache _memoryCache;
         private readonly IHttpContextAccessor _httpContextAccessor;
@@ -33,6 +35,10 @@ namespace ArgonFetch.Application.Queries
         private readonly IMediaUrlCacheService _cacheService;
         private readonly IProxyUrlBuilder _proxyUrlBuilder;
         private readonly IProxyPool _proxyPool;
+
+        // Enough to hold the album version when search leads with a radio edit and a remaster,
+        // and few enough that a mistyped query does not drag twenty rows through matching.
+        private const int SearchResultsToConsider = 20;
 
         // Wrong-recording candidates come in runs - a radio edit, a remaster and a twelve-inch
         // mix all sit above the album version - so checking a couple past the leader is worth a
@@ -49,7 +55,7 @@ namespace ArgonFetch.Application.Queries
 
         public GetMediaQueryHandler(
             ISpotifyMetadataService spotifyMetadataService,
-            YTMusicAPI.SearchClient ytmSearchClient,
+            YouTubeMusicClient ytmClient,
             YoutubeDL youtubeDL,
             TikTokDllFetcherService tikTokDllFetcherService,
             IMemoryCache memoryCache,
@@ -61,7 +67,7 @@ namespace ArgonFetch.Application.Queries
             )
         {
             _spotifyMetadataService = spotifyMetadataService;
-            _ytmSearchClient = ytmSearchClient;
+            _ytmClient = ytmClient;
             _youtubeDL = youtubeDL;
             _tikTokDllFetcherService = tikTokDllFetcherService;
             _memoryCache = memoryCache;
@@ -339,6 +345,11 @@ namespace ArgonFetch.Application.Queries
             (long?)(format.FileSize ?? format.ApproximateFileSize));
 
         /// <summary>
+        /// The watch page for a song id, which is what yt-dlp is given to fetch.
+        /// </summary>
+        private static string WatchUrl(string id) => $"https://music.youtube.com/watch?v={id}";
+
+        /// <summary>
         /// Fetches candidates in order until one turns out to be the requested recording.
         /// </summary>
         /// <param name="requireDuration">
@@ -349,7 +360,7 @@ namespace ArgonFetch.Application.Queries
         private async Task<VideoData?> FetchVerifiedAgainstSpotify(
             IReadOnlyList<MatchCandidate> ranked,
             List<MatchCandidate> candidates,
-            List<YTMusicAPI.Model.Domain.Track> results,
+            List<SongSearchResult> results,
             SpotifyTrackMetadata track,
             CancellationToken cancellationToken,
             bool requireDuration = false)
@@ -364,7 +375,7 @@ namespace ArgonFetch.Application.Queries
 
                 // Reference equality, not IndexOf: MatchCandidate is a record, so two results with
                 // the same title, artist and length would compare equal and resolve to the wrong URL.
-                var url = results[candidates.FindIndex(c => ReferenceEquals(c, candidate))].Url;
+                var url = WatchUrl(results[candidates.FindIndex(c => ReferenceEquals(c, candidate))].Id);
 
                 VideoData fetched;
 
@@ -504,21 +515,23 @@ namespace ArgonFetch.Application.Queries
             // YouTube Music result.
             var searchQuery = YouTubeMusicMatcher.SearchQuery(track.Artist, track.Title);
 
-            var response = await _ytmSearchClient.SearchTracksAsync(new YTMusicAPI.Model.QueryRequest
-            {
-                Query = searchQuery
-            }, cancellationToken);
-
-            var results = response.Result.ToList();
+            var results = (await _ytmClient
+                    .SearchAsync(searchQuery, SearchCategory.Songs)
+                    .FetchItemsAsync(0, SearchResultsToConsider, cancellationToken))
+                .OfType<SongSearchResult>()
+                .ToList();
 
             // Taking the first hit matches covers, karaoke versions and instrumentals as readily as
             // the real recording, so score the candidates instead.
             var candidates = results
                 .Select(r => new MatchCandidate(
-                    r.Title ?? string.Empty,
-                    r.Author,
-                    (long)(r.Duration?.TotalSeconds ?? 0),
-                    r.Author ?? string.Empty))
+                    r.Name,
+                    string.Join(", ", r.Artists.Select(artist => artist.Name)),
+                    (long)r.Duration.TotalSeconds,
+                    // The release, which is where an instrumental or a solo cut declares itself.
+                    // The previous client offered no album at all, so this carried the artist
+                    // again and the check that reads it never had anything to find.
+                    r.Album?.Name ?? string.Empty))
                 .ToList();
 
             var ranked = YouTubeMusicMatcher.RankMatches(
@@ -528,10 +541,10 @@ namespace ArgonFetch.Application.Queries
                 track.DurationMs,
                 officialShelf: true);
 
-            // Search never reports a duration - YTMusicAPI returns null for every row - so the
-            // one signal that separates an album version from its radio edit is missing while
-            // ranking. Fetching a candidate does report it, so the pick is checked rather than
-            // trusted, and the next candidate tried when it does not fit.
+            // A safety net rather than the mechanism: search reports durations now, so ranking
+            // usually settles which recording this is and the first candidate is the answer.
+            // Fetching still confirms it, because a length search got wrong would otherwise be
+            // discovered by whoever opened the file.
             var result = await FetchVerifiedAgainstSpotify(ranked, candidates, results, track, cancellationToken);
 
             if (result is null)
@@ -540,7 +553,7 @@ namespace ArgonFetch.Application.Queries
                 // says the Japanese original - and then no candidate shares a single word with
                 // what was asked for. The credit still matches, and the duration decides, so
                 // this pass drops the title requirement and leans on the check instead.
-                var byCredit = YouTubeMusicMatcher.RankByCreditOnly(candidates, track.Artist);
+                var byCredit = YouTubeMusicMatcher.RankByCreditOnly(candidates, track.Artist, track.DurationMs);
 
                 result = await FetchVerifiedAgainstSpotify(byCredit, candidates, results, track, cancellationToken, requireDuration: true);
             }

--- a/src/ArgonFetch.Application/Services/YouTubeMusicMatcher.cs
+++ b/src/ArgonFetch.Application/Services/YouTubeMusicMatcher.cs
@@ -22,6 +22,11 @@ namespace ArgonFetch.Application.Services
     public static class YouTubeMusicMatcher
     {
         internal const long DurationToleranceSec = 30L;
+
+        // Tighter than the tolerance used when a title matched. Nothing but the length is
+        // identifying the track on that path, and another track by the same artist is often
+        // within a few seconds of the one that was asked for.
+        internal const long CreditOnlyToleranceSec = 4L;
         internal const long DurationBucketSec = 5L;
         internal const double MinTitleScore = 0.8;
         internal const string UnknownPlaceholder = "Unknown";
@@ -102,9 +107,9 @@ namespace ArgonFetch.Application.Services
 
             var ordered = viable.Select((candidate, index) => (candidate, index));
 
-            // Duration is a tiebreaker, not a requirement. Some search backends do not report it
-            // at all - YTMusicAPI returns null for every row - and filtering on it then discards
-            // every candidate and resolves nothing.
+            // Duration is a tiebreaker, not a requirement. Not every search backend reports it,
+            // and filtering on it when it is missing discards every candidate and resolves
+            // nothing.
             var timed = viable.Where(c => c.DurationSec > 0).ToList();
 
             if (durationMs <= 0L || timed.Count == 0)
@@ -144,7 +149,8 @@ namespace ArgonFetch.Application.Services
         /// </summary>
         public static IReadOnlyList<MatchCandidate> RankByCreditOnly(
             IReadOnlyList<MatchCandidate> candidates,
-            string wantArtist)
+            string wantArtist,
+            long durationMs = 0L)
         {
             var wantArtistWords = Words(RealArtist(wantArtist));
 
@@ -153,9 +159,24 @@ namespace ArgonFetch.Application.Services
 
             var asked = new HashSet<string>(MarkerWords(wantArtist), StringComparer.Ordinal);
 
-            return candidates
+            var viable = candidates
                 .Where(c => ArtistMatches(c.Artist, wantArtistWords, allowScriptMismatch: false) &&
                             !AddsRework($"{c.Title} {BracketedIn(c.Details)}", asked))
+                .ToList();
+
+            var timed = viable.Where(c => c.DurationSec > 0).ToList();
+
+            if (durationMs <= 0L || timed.Count == 0)
+                return viable;
+
+            var wantSec = durationMs / 1000;
+
+            // Closest first rather than search order: the artist's other tracks are in this list
+            // too, and one of them being a few seconds from the right length is not a reason to
+            // prefer it to an exact match.
+            return timed
+                .Where(c => Math.Abs(c.DurationSec - wantSec) <= CreditOnlyToleranceSec)
+                .OrderBy(c => Math.Abs(c.DurationSec - wantSec))
                 .ToList();
         }
 
@@ -164,9 +185,8 @@ namespace ArgonFetch.Application.Services
         /// <para>
         /// Search returns the radio edit, the remaster and the twelve-inch mix alongside the
         /// album version, all with the right title and the right credit. Where no duration is
-        /// available to separate them - and YTMusicAPI never provides one - the plainest title
-        /// is the one that was asked for. Counted with brackets kept, because that is where the
-        /// qualifier lives.
+        /// available to separate them, the plainest title is the one that was asked for.
+        /// Counted with brackets kept, because that is where the qualifier lives.
         /// </para>
         /// </summary>
         internal static int ExtraWords(string candidateTitle, ISet<string> asked) =>

--- a/src/ArgonFetch.Tests/YouTubeMusicMatcherTests.cs
+++ b/src/ArgonFetch.Tests/YouTubeMusicMatcherTests.cs
@@ -149,7 +149,7 @@ namespace ArgonFetch.Tests
         [Fact]
         public void BestMatch_IgnoresLengthWhenTheSourceReportsNone()
         {
-            // YTMusicAPI returns no duration at all for some rows. Filtering on it then discards
+            // Not every search backend reports a duration. Filtering on it then discards
             // every candidate and the track resolves to nothing.
             var noDuration = Candidate("Never Gonna Give You Up", durationSec: 0);
 
@@ -189,8 +189,8 @@ namespace ArgonFetch.Tests
         [Fact]
         public void BestMatch_PrefersThePlainestTitleWhenNothingElseSeparatesCandidates()
         {
-            // Search returns the radio edit above the album version, and YTMusicAPI reports no
-            // duration for either, so without this the edit wins on search order alone.
+            // Search returns the radio edit above the album version. Where neither carries a
+            // duration, without this the edit wins on search order alone.
             var radioEdit = Candidate("One More Time (Radio Edit)", artist: "Daft Punk", durationSec: 0);
             var albumVersion = Candidate("One More Time", artist: "Daft Punk", durationSec: 0);
 
@@ -235,6 +235,22 @@ namespace ArgonFetch.Tests
             var someoneElse = new MatchCandidate("Bのリベンジ", "歌っちゃ王", 0, "歌っちゃ王");
 
             Assert.Empty(YouTubeMusicMatcher.RankByCreditOnly([instrumental, someoneElse], wanted));
+        }
+
+        [Fact]
+        public void RankByCreditOnly_TakesTheClosestLengthRatherThanTheFirstThatFits()
+        {
+            // The artist's other tracks are in the same search, and one of them landing a few
+            // seconds from the right length is not a reason to prefer it to an exact match.
+            const string artist = "B小町 ルビー（CV：伊駒ゆりえ）";
+
+            var nearby = new MatchCandidate("深海52Hz", artist, 175, artist);
+            var exact = new MatchCandidate("Bのリベンジ", artist, 182, artist);
+
+            var ranked = YouTubeMusicMatcher.RankByCreditOnly([nearby, exact], artist, durationMs: 182_000);
+
+            Assert.Equal(exact, ranked.First());
+            Assert.DoesNotContain(nearby, ranked);
         }
 
         [Fact]


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [x] Refactoring

## Description
The old search client (`YTMusicAPI 1.0.7`) returned a title, a credited name, and nothing else:

- **No duration on any row**, which left the matcher''s strongest signal with no data at all - and is why Daft Punk''s "One More Time" resolved to the radio edit.
- **No album**, so the check that reads a release to spot an instrumental or a solo cut was being handed the artist string again and never had anything to find.
- Two of its three richer calls are broken in that version: `GetAlbumTracksAsync` throws `NullReferenceException`, `GetTrackInfoAsync` returns HTTP 400.

`IcySnex/YouTubeMusicAPI` returns all of it - a duration and an album per row, and artists as a list rather than one concatenated string. Ranking now settles which recording it is *before* anything is fetched, and the fetch that follows confirms the choice rather than making it.

**Search and metadata only.** Its streaming endpoints want a PoToken and answer 403 to addresses that look like VPNs - which is what a rotated proxy looks like - so yt-dlp keeps fetching the media exactly as before.

## Testing
Probed the live search directly, which is where the evidence is:

```
Daft Punk "One More Time" (Spotify 320s)
  1. 'One More Time' 321s [Discovery]        ← album version now leads
  2. 'One More Time (Radio Edit)' 321s

"REVENGE OF B" (Spotify 182s)
  by title:       (none)   ← Spotify''s English title, YouTube''s Japanese one, no shared word
  by credit:      'Bのリベンジ' 182s ← identified by length, at search time
```

End to end against a live API, measuring what is served: Daft Punk **320s** (the album version; the radio edit is 236s), Rick Astley **214s**, five audio renditions on both, YouTube path unchanged. 92 unit tests pass.

Measured rather than assumed, since Jint is a JavaScript interpreter:

| | before | after |
|---|---|---|
| published output | 15.3 MB | 17.7 MB (+2.4 MB) |
| startup to first response | - | 2.6s |
| Spotify fetch | 5-8s | 4-7s |

The old package also turned out to be referenced *twice* - `ArgonFetch.API` had its own reference alongside `ArgonFetch.Application` - so removing it from one project left the DLL in the published output. Both are gone now.

One tightening came out of the probe: the credit-only path used ±12s and took the first candidate that fit, and another track by the same artist sat 7s from the wanted length. It now uses ±4s and takes the **closest**, not the first.

## Impact
`YTMusicAPI` is replaced by `YouTubeMusicAPI`, pinned to **3.0.10** - a v4 recode is underway and will not keep this API, so the pin is deliberate rather than incidental. +2.4 MB in the image, no measurable change in startup or fetch time. Nothing about how media is fetched or streamed changes.

## Issue related to PR
- Resolves #

## Additional Information
Two capabilities this opens up but does not use: `GetAlbumInfoAsync` would allow picking a track from the artist''s own album, which rules out covers outright, and the album name is now available as a matching signal in its own right.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
