### PR TITLE
Let an operator supply a session for sources that require one

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ streams and serves them back as a normal file download.
 | Spotify | ✅ Single tracks | Metadata is read from the public track page; audio comes from the matching YouTube Music result |
 | TikTok | ✅ | |
 | SoundCloud | ✅ | Except the licensed catalogue, which is DRM protected and refused |
-| Instagram | ❌ Needs a signed-in session | Instagram serves media only to logged-in accounts, and ArgonFetch has no way to supply credentials |
+| Instagram | ⚠️ Needs `COOKIES_PATH` | Instagram serves media only to a signed-in session; supply one and it works |
 | Spotify playlists / albums | ❌ Not supported | [#171](https://github.com/ArgonFetch/ArgonFetch/issues/171) |
 | Playlists generally | ❌ Not supported | [#76](https://github.com/ArgonFetch/ArgonFetch/issues/76) |
 
@@ -123,6 +123,7 @@ Everything is set through environment variables in `.env`.
 | `CORS_ALLOWED_ORIGINS` | in production | Comma-separated origins allowed to call the API. Defaults to `http://localhost:4200`, and the app warns at startup if that default is still in use in production |
 | `ASPNETCORE_ENVIRONMENT` | no | `Production` by default. `Development` also enables Swagger UI |
 | `PROXY_LIST_PATH` | no | File with one proxy per line, rotated across yt-dlp fetches so they do not all leave from the same IP. See below |
+| `COOKIES_PATH` | no | Netscape-format cookies file, for sources that serve media only to a signed-in session. See below |
 
 ### Media tooling
 
@@ -134,6 +135,28 @@ is enough to recover from a broken version.
 
 Mount a volume at `/tools` (the compose file above does) so the binaries survive restarts.
 Without one, roughly 100MB is downloaded again every time the container starts.
+
+### Signed-in sources
+
+Some sources serve nothing to a signed-out request. Instagram is the clearest case - it
+requires a session for practically everything - and an age-gated YouTube video wants one
+too. Point `COOKIES_PATH` at a Netscape-format cookies file exported from a browser that is
+logged in, and every extraction offers it:
+
+```env
+COOKIES_PATH=/config/cookies.txt
+```
+
+```yaml
+    volumes:
+      - ./cookies.txt:/config/cookies.txt:ro
+```
+
+Without it those sources answer `415` saying a session is needed, rather than pretending the
+link is wrong. A path pointing at a file that is not there is ignored, so a mistake in the
+setting does not break every other fetch.
+
+Treat the file as a credential: anyone holding it is signed in as you.
 
 ### Proxy rotation
 

--- a/compose.yml
+++ b/compose.yml
@@ -23,6 +23,9 @@ services:
       # yt-dlp and FFmpeg are fetched on boot rather than baked into the image. Keeping them
       # here means a restart reuses them instead of downloading roughly 100MB again.
       - tools:/tools
+      # Uncomment for sources that need a signed-in session, e.g. Instagram, and set
+      # COOKIES_PATH=/config/cookies.txt in .env. Treat the file as a credential.
+      # - ./cookies.txt:/config/cookies.txt:ro
     depends_on:
       - postgres
     restart: unless-stopped

--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -54,7 +54,9 @@ builder.Services.AddMemoryCache();
 // yt-dlp is fetched when the app boots and kept current from there, so the image ships
 // without it and a restart is enough to pick up an extractor fix.
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IToolPaths>(
-    new ArgonFetch.Application.Services.ToolPaths(builder.Configuration["TOOLS_PATH"]));
+    new ArgonFetch.Application.Services.ToolPaths(
+        builder.Configuration["TOOLS_PATH"],
+        builder.Configuration["COOKIES_PATH"]));
 builder.Services.AddSingleton<ArgonFetch.Infrastructure.Services.MediaToolsService>();
 builder.Services.AddHostedService(
     sp => sp.GetRequiredService<ArgonFetch.Infrastructure.Services.MediaToolsService>());

--- a/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
@@ -35,6 +35,7 @@ namespace ArgonFetch.Application.Queries
         private readonly IMediaUrlCacheService _cacheService;
         private readonly IProxyUrlBuilder _proxyUrlBuilder;
         private readonly IProxyPool _proxyPool;
+        private readonly IToolPaths _toolPaths;
 
         // Enough to hold the album version when search leads with a radio edit and a remaster,
         // and few enough that a mistyped query does not drag twenty rows through matching.
@@ -63,7 +64,8 @@ namespace ArgonFetch.Application.Queries
             ICombinedStreamUrlBuilder combinedUrlBuilder,
             IMediaUrlCacheService cacheService,
             IProxyUrlBuilder proxyUrlBuilder,
-            IProxyPool proxyPool
+            IProxyPool proxyPool,
+            IToolPaths toolPaths
             )
         {
             _spotifyMetadataService = spotifyMetadataService;
@@ -76,6 +78,7 @@ namespace ArgonFetch.Application.Queries
             _cacheService = cacheService;
             _proxyUrlBuilder = proxyUrlBuilder;
             _proxyPool = proxyPool;
+            _toolPaths = toolPaths;
         }
 
         public async Task<ResourceInformationDto> Handle(GetMediaQuery request, CancellationToken cancellationToken)
@@ -465,6 +468,10 @@ namespace ArgonFetch.Application.Queries
         {
             options ??= new OptionSet { DumpSingleJson = true };
 
+            // Not only for Instagram: an age-gated YouTube video needs a session too, and a
+            // source that does not care simply ignores them.
+            options.Cookies = _toolPaths.CookiesPath;
+
             if (!Uri.IsWellFormedUriString(query, UriKind.Absolute))
             {
                 _fetchProxy = _proxyPool.Next();
@@ -473,6 +480,7 @@ namespace ArgonFetch.Application.Queries
                 {
                     NoPlaylist = true,
                     Proxy = _fetchProxy,
+                    Cookies = _toolPaths.CookiesPath,
                 };
 
                 var searchResult = await _youtubeDL.RunVideoDataFetch($"ytsearch:{query}", overrideOptions: searchOptions);
@@ -500,6 +508,14 @@ namespace ArgonFetch.Application.Queries
                 // whoever pasted the link: DRM is a refusal, not a bad address.
                 if (YtDlpErrors.IsDrmProtected(result.ErrorOutput))
                     throw new NotSupportedException("This media is DRM protected and cannot be downloaded.");
+
+                // Told apart from a missing page for the same reason as DRM: the link is right
+                // and the fix is a cookies file, which the reader can actually act on.
+                if (YtDlpErrors.NeedsSignedInSession(result.ErrorOutput))
+                    throw new NotSupportedException(
+                        _toolPaths.CookiesPath is null
+                            ? "This source serves media only to a signed-in session. Set COOKIES_PATH to a Netscape-format cookies file exported from a logged-in browser."
+                            : "This source rejected the configured session. The cookies file may have expired.");
 
                 throw new ArgumentException($"Failed to fetch data: {errors}");
             }

--- a/src/ArgonFetch.Application/Services/ToolPaths.cs
+++ b/src/ArgonFetch.Application/Services/ToolPaths.cs
@@ -10,6 +10,13 @@
 
         /// <summary>Full path of the FFmpeg binary, whether or not it exists yet.</summary>
         string FfmpegPath { get; }
+
+        /// <summary>
+        /// A Netscape-format cookies file to extract with, or null when none is configured or
+        /// the configured one is not there. Sources that serve media only to a signed-in
+        /// session - Instagram serves nothing without one - need it; everything else ignores it.
+        /// </summary>
+        string? CookiesPath { get; }
     }
 
     /// <summary>
@@ -20,8 +27,15 @@
     /// </summary>
     public class ToolPaths : IToolPaths
     {
-        public ToolPaths(string? toolsDirectory)
+        public ToolPaths(string? toolsDirectory, string? cookiesPath = null)
         {
+            // Checked once here rather than on every fetch: a path pointing at nothing is a
+            // configuration mistake, and passing it to yt-dlp fails every extraction with an
+            // error about cookies rather than about the media.
+            CookiesPath = !string.IsNullOrWhiteSpace(cookiesPath) && File.Exists(cookiesPath)
+                ? cookiesPath
+                : null;
+
             ToolsDirectory = string.IsNullOrWhiteSpace(toolsDirectory)
                 ? Path.Combine(AppContext.BaseDirectory, "tools")
                 : toolsDirectory;
@@ -37,5 +51,7 @@
         public string YtDlpPath { get; }
 
         public string FfmpegPath { get; }
+
+        public string? CookiesPath { get; }
     }
 }

--- a/src/ArgonFetch.Application/Services/YtDlpErrors.cs
+++ b/src/ArgonFetch.Application/Services/YtDlpErrors.cs
@@ -1,4 +1,4 @@
-namespace ArgonFetch.Application.Services
+﻿namespace ArgonFetch.Application.Services
 {
     /// <summary>
     /// Reads what yt-dlp printed when a fetch failed, so the API can say why rather than
@@ -12,6 +12,23 @@ namespace ArgonFetch.Application.Services
         /// missing sends the reader looking for a mistake that is not there.
         /// </summary>
         public static bool IsDrmProtected(IEnumerable<string>? errorOutput) =>
-            errorOutput?.Any(line => line?.Contains("DRM", StringComparison.OrdinalIgnoreCase) == true) == true;
+            Mentions(errorOutput, "DRM");
+
+        /// <summary>
+        /// Whether the source refused because nobody was signed in. Instagram answers this way
+        /// for practically everything now, and an age-gated YouTube video does the same, so the
+        /// answer is a cookies file rather than a different link.
+        /// </summary>
+        public static bool NeedsSignedInSession(IEnumerable<string>? errorOutput) =>
+            Mentions(errorOutput, "login required") ||
+            Mentions(errorOutput, "log in") ||
+            Mentions(errorOutput, "sign in") ||
+            Mentions(errorOutput, "cookies") ||
+            // Instagram's own wording when it serves nothing to a signed-out request.
+            Mentions(errorOutput, "empty media response") ||
+            Mentions(errorOutput, "rate-limit reached");
+
+        private static bool Mentions(IEnumerable<string>? errorOutput, string phrase) =>
+            errorOutput?.Any(line => line?.Contains(phrase, StringComparison.OrdinalIgnoreCase) == true) == true;
     }
 }

--- a/src/ArgonFetch.Tests/YtDlpErrorsTests.cs
+++ b/src/ArgonFetch.Tests/YtDlpErrorsTests.cs
@@ -18,6 +18,27 @@ namespace ArgonFetch.Tests
         }
 
         [Theory]
+        // Instagram's wording when it serves nothing to a signed-out request.
+        [InlineData("ERROR: [Instagram] ABC: Instagram sent an empty media response. Check if this post is accessible in your browser without being logged-in.")]
+        [InlineData("ERROR: [youtube] xyz: Sign in to confirm your age. Use --cookies-from-browser or --cookies.")]
+        [InlineData("ERROR: [instagram] Requested content is not available, rate-limit reached or login required.")]
+        public void NeedsSignedInSession_RecognisesARefusalACookiesFileWouldFix(string error)
+        {
+            Assert.True(YtDlpErrors.NeedsSignedInSession([error]));
+        }
+
+        [Theory]
+        [InlineData("ERROR: [youtube] abc: Video unavailable")]
+        [InlineData("ERROR: [soundcloud] 1: This video is DRM protected")]
+        [InlineData(null)]
+        public void NeedsSignedInSession_LeavesOtherFailuresAlone(string? error)
+        {
+            // Only refusals a cookies file can actually fix should say so; the rest are still
+            // "not found", and telling someone to export cookies would waste their time.
+            Assert.False(YtDlpErrors.NeedsSignedInSession(error is null ? null : [error]));
+        }
+
+        [Theory]
         [InlineData(null)]
         public void IsDrmProtected_HandlesNothingToRead(string[]? errorOutput)
         {


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [x] Bug fix

## Description
Half of #58 fixed itself and the other half needed something from the operator.

**SoundCloud works.** Whatever broke it in March 2025 is gone - most likely a yt-dlp extractor fix, which now lands automatically since the container fetches yt-dlp at boot. A track returns title, author and cover, and streams 2,208,495 bytes of mp3.

**Instagram never could work**, because it serves nothing to a signed-out request - yt-dlp itself refuses with "Instagram sent an empty media response. Check if this post is accessible in your browser without being logged-in." Both a reel and a post came back as `404 Resource Not Found`, which reads as a wrong link when the link is fine.

`COOKIES_PATH` now points at a Netscape-format cookies file, and every extraction offers it - so a source that wants a session gets one, and everything else ignores it. Not only Instagram: an age-gated YouTube video wants one too.

A path pointing at a file that is not there is treated as unset rather than passed on, because yt-dlp given a missing cookies file fails *every* fetch with an error about cookies rather than about media.

## Testing
Against a live API:

| case | before | after |
|---|---|---|
| Instagram reel, no session | `404 Resource Not Found` | `415` - "This source serves media only to a signed-in session. Set COOKIES_PATH to a Netscape-format cookies file exported from a logged-in browser." |
| Instagram reel, session configured | - | `415` - "This source rejected the configured session. The cookies file may have expired." |
| SoundCloud | 200 | 200, unchanged |
| YouTube | 200 | 200, unchanged - including with a cookies file configured |

Five unit tests cover the detection, including that a plain "Video unavailable" and a DRM refusal are **not** reported as needing a session - telling someone to export cookies when that would not help wastes their time.

**What I could not verify:** that a real Instagram session downloads successfully. That needs someone''s logged-in cookies, which I am not going to ask for. What is verified is the plumbing - a configured file reaches yt-dlp, an absent one is ignored, and the two failure messages are correct.

## Impact
No change unless `COOKIES_PATH` is set. One failure mode moves from 404 to 415 with an actionable reason.

## Issue related to PR
- Resolves #58

## Additional Information
The README notes the file should be treated as a credential: anyone holding it is signed in as whoever exported it. The platform table now reads "Needs `COOKIES_PATH`" for Instagram rather than claiming it cannot work.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
