### PR TITLE
Match a track whose version Spotify hyphenates and YouTube Music brackets

### DIFF
--- a/src/ArgonFetch.Application/Services/YouTubeMusicMatcher.cs
+++ b/src/ArgonFetch.Application/Services/YouTubeMusicMatcher.cs
@@ -217,9 +217,8 @@ namespace ArgonFetch.Application.Services
                 : artist ?? string.Empty;
 
         /// <summary>
-        /// Like Words but keeps bracketed text. Titles score with brackets dropped, so
-        /// "Song (feat. X)" still matches "Song" - but that also erased the one thing marking a
-        /// rework, and "(Instrumental)" became indistinguishable from the real recording: same
+        /// Like Words but keeps bracketed text - which is where a release says what it is.
+        /// Dropping it made "(Instrumental)" indistinguishable from the real recording: same
         /// title, same artist, same length.
         /// </summary>
         private static HashSet<string> MarkerWords(string s) =>
@@ -260,12 +259,23 @@ namespace ArgonFetch.Application.Services
         private static bool HasLatin(IEnumerable<string> words) =>
             words.Any(word => word.Any(c => c >= 'a' && c <= 'z'));
 
-        /// <summary>Share of the wanted title's words the candidate carries.</summary>
+        /// <summary>
+        /// Share of the wanted title's words the candidate carries.
+        /// <para>
+        /// Counted with the candidate's brackets kept. The two sides write a version qualifier
+        /// differently - Spotify hyphenates it into the name, "World is Mine - Kaguya&amp;Yachiyo
+        /// Runami ver. - CPK! Remix", where YouTube Music brackets it - so dropping the brackets
+        /// erased the half of the candidate that the request was mostly made of, and an exact
+        /// match scored a third. Keeping them cannot cost a match either way: the score measures
+        /// how much of the wanted title the candidate carries, so words the candidate has and
+        /// nobody asked for were never counted against it.
+        /// </para>
+        /// </summary>
         internal static double TitleScore(string candidateTitle, ISet<string> want)
         {
             if (want.Count == 0) return 0.0;
 
-            var have = Words(candidateTitle);
+            var have = MarkerWords(candidateTitle);
             return want.Count(w => have.Any(h => NearlyEqual(h, w))) / (double)want.Count;
         }
 

--- a/src/ArgonFetch.Tests/YouTubeMusicMatcherTests.cs
+++ b/src/ArgonFetch.Tests/YouTubeMusicMatcherTests.cs
@@ -264,6 +264,40 @@ namespace ArgonFetch.Tests
             Assert.Empty(YouTubeMusicMatcher.RankByCreditOnly([candidate], ""));
         }
 
+        [Fact]
+        public void RankMatches_FindsATrackWhoseVersionSpotifyHyphenatesAndYouTubeBrackets()
+        {
+            // Real rows from a YouTube Music search, and the Spotify track that failed to
+            // resolve against them. Spotify writes the version into the name after a hyphen;
+            // YouTube Music brackets it and puts the romanisation after the Japanese original.
+            const string wantTitle = "World is Mine - Kaguya&Yachiyo Runami ver. - CPK! Remix";
+            const string wantArtist = "ryo (supercell), Kaguya(cv.Yuko Natsuyoshi), Yachiyo Runami(cv.Saori Hayami)";
+
+            var asked = new MatchCandidate(
+                "\u30EF\u30FC\u30EB\u30C9\u30A4\u30BA\u30DE\u30A4\u30F3 (\u304B\u3050\u3084&\u6708\u898B\u30E4\u30C1\u30E8 ver.) [CPK! Remix] - World Is Mine (Kaguya&Yachiyo Runami Ver.) [CPK! Remix]",
+                "ryo (supercell), Kaguya(cv.Yuko Natsuyoshi), Yachiyo Runami(cv.Saori Hayami)",
+                100);
+
+            // The same remix sung by someone else, which is not what was asked for.
+            var otherVersion = new MatchCandidate(
+                "\u30EF\u30FC\u30EB\u30C9\u30A4\u30BA\u30DE\u30A4\u30F3 (Anime ver.) [CPK! Remix] - World Is Mine (Anime Ver.) [CPK! Remix] (feat. ChoKaguyaHime)",
+                "supercell und Yachiyo Runami(cv.Saori Hayami)",
+                100);
+
+            var ranked = YouTubeMusicMatcher.RankMatches([otherVersion, asked], wantTitle, wantArtist, durationMs: 0);
+
+            Assert.Equal(asked, ranked.FirstOrDefault());
+        }
+
+        [Fact]
+        public void TitleScore_ReadsAQualifierTheCandidateKeepsInBrackets()
+        {
+            var want = YouTubeMusicMatcher.TitleWords("Sonne - Live Version");
+
+            // Bracketed on the candidate, hyphenated on the request: the same words either way.
+            Assert.Equal(1.0, YouTubeMusicMatcher.TitleScore("Sonne (Live Version)", want));
+        }
+
         [Theory]
         // A leading hyphen is a search operator - it tells YouTube to drop every result
         // containing the word, so the shelf came back empty for tracks named this way.


### PR DESCRIPTION
## The problem

`World is Mine - Kaguya&Yachiyo Runami ver. - CPK! Remix` came back as not found, although it is the **first hit** on that YouTube Music search.

Spotify hyphenates a version qualifier into the track name. YouTube Music brackets it, and puts the romanisation after the Japanese original:

| | |
|---|---|
| Spotify asks for | `World is Mine - Kaguya&Yachiyo Runami ver. - CPK! Remix` |
| YouTube Music offers | `ワールドイズマイン (かぐや&月見ヤチヨ ver.) [CPK! Remix] - World Is Mine (Kaguya&Yachiyo Runami Ver.) [CPK! Remix]` |

Scoring stripped the candidate's brackets first, leaving `ワールドイズマイン world is mine`. Three of the nine wanted words survived - 0.33 against a 0.8 threshold - so the exact match was thrown out, along with every other version of the track.

## The fix

Titles now score with the candidate's brackets kept. This cannot cost a match either way: the score measures how much of the *wanted* title the candidate carries, so words the candidate has and nobody asked for were never counted against it. Stripping them only ever removed evidence.

The version qualifier now discriminates instead of disappearing. Of the four remixes that search returns:

| Candidate | Score |
|---|---|
| Kaguya&Yachiyo Runami ver. - **the one asked for** | 1.00 |
| Anime ver. | 0.67 |
| Yanaginagi ver. | 0.67 |
| plain CPK! Remix | 0.55 |

## Testing

- 104 unit tests pass - no regressions, plus two new cases built from the real search rows.
- Live: the track resolves and serves (5 renditions, ranged request returns 206).
- Live spot-check that the looser score did not start mismatching: Rick Astley, bbno$, The Weeknd and a plain YouTube link all resolve to the right recording.
