### PR TITLE
Delete an endpoint that was commented out and a dependency nothing used

### DIFF
--- a/src/ArgonFetch.API/Controllers/AppController.cs
+++ b/src/ArgonFetch.API/Controllers/AppController.cs
@@ -1,6 +1,5 @@
 ﻿using ArgonFetch.Application.Dtos;
 using ArgonFetch.Application.Services;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ArgonFetch.API.Controllers
@@ -9,14 +8,12 @@ namespace ArgonFetch.API.Controllers
     [Route("api/[controller]")]
     public class AppController : ControllerBase
     {
-        private readonly IMediator _mediator;
         private readonly IWebHostEnvironment _environment;
         private readonly IApplicationInfoService _applicationInfoService;
         private readonly IMaintenanceState _maintenance;
 
-        public AppController(IMediator mediator, IWebHostEnvironment environment, IApplicationInfoService applicationInfoService, IMaintenanceState maintenance)
+        public AppController(IWebHostEnvironment environment, IApplicationInfoService applicationInfoService, IMaintenanceState maintenance)
         {
-            _mediator = mediator;
             _environment = environment;
             _applicationInfoService = applicationInfoService;
             _maintenance = maintenance;

--- a/src/ArgonFetch.API/Controllers/FetchController.cs
+++ b/src/ArgonFetch.API/Controllers/FetchController.cs
@@ -86,44 +86,5 @@ namespace ArgonFetch.API.Controllers
                 });
             }
         }
-
-        //[HttpGet("DownloadResource", Name = "DownloadResource")]
-        //[ProducesResponseType(typeof(ResourceInformationDto), StatusCodes.Status200OK)]
-        //[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-        //[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-        //[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status415UnsupportedMediaType)]
-        //[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status502BadGateway)]
-        //public async Task<ActionResult<ResourceInformationDto>> DownloadResource(string url)
-        //{
-        //    try
-        //    {
-        //        var result = await _mediator.Send(new DownloadMediaQuery(url));
-        //        return Ok(result);
-        //    }
-        //    catch (ArgumentException ex)
-        //    {
-        //        return NotFound(new ProblemDetails
-        //        {
-        //            Title = "Resource Not Found",
-        //            Status = StatusCodes.Status404NotFound
-        //        });
-        //    }
-        //    catch (NotSupportedException ex)
-        //    {
-        //        return StatusCode(StatusCodes.Status415UnsupportedMediaType, new ProblemDetails
-        //        {
-        //            Title = "Unsupported Media Type",
-        //            Status = StatusCodes.Status415UnsupportedMediaType
-        //        });
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        return StatusCode(StatusCodes.Status502BadGateway, new ProblemDetails
-        //        {
-        //            Title = "Fetch Failed",
-        //            Status = StatusCodes.Status502BadGateway
-        //        });
-        //    }
-        //}
     }
 }


### PR DESCRIPTION
## Type of Change
- [x] Refactoring

## Description

An audit of the API surface after #211 and #213. **No live endpoint was removed** — all six are
reached from the frontend:

| Endpoint | Called from |
|---|---|
| `GET /api/App` | `app.component.ts`, via the generated client |
| `GET /api/Fetch/GetResource` | `home.component.ts`, `playlist-container.component.ts` |
| `GET /api/Stream/Combined/{key}` | `resource-url.service.ts`, as a built URL |
| `GET /api/Stream/Media/{key}` | `resource-url.service.ts`, as a built URL |
| `GET /api/Stream/Archive` | `resource-url.service.ts` / `archive-download.service.ts` |
| `GET /api/Stream/Archive/Progress/{jobId}` | `archive-download.service.ts`, via `EventSource` |

The four `Stream` routes look unused if you search for generated-client calls, because the
frontend builds those URLs by hand. Worth knowing before anyone prunes them.

Two dead things did turn up, and those are what this removes:

**The commented-out `DownloadResource` endpoint** in `FetchController` — 41 lines calling
`new DownloadMediaQuery(url)`, a type that no longer exists in the solution. It could not have
been uncommented even by someone who wanted it back.

**`AppController`'s `IMediator`** — injected, assigned, read nowhere. `GetAppInfo` builds its
response from `IApplicationInfoService`, `IWebHostEnvironment` and `IMaintenanceState`.

## Testing

`dotnet build` clean, `dotnet test` 118 passing.

Removing a constructor parameter is resolved by DI at runtime rather than at compile time, so
I ran it: `GET /api/App` → `200` with the expected payload, `GET /api/Fetch/GetResource`
against a YouTube URL → `200`, and the generated Swagger document lists exactly the six paths
above and nothing else.

## Impact

None on behaviour. No route added or removed, so the checked-in OpenAPI schema and the
generated client are unchanged.

## Issue related to PR
- Resolves #215

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.