### PR TITLE
Correct docs that outlived what they described

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ streams and serves them back as a normal file download.
 | Platform | Status | Notes |
 |---|---|---|
 | YouTube | ✅ Video and audio | Muxes separate video/audio streams when no pre-muxed format exists |
-| Spotify | ✅ Single tracks | Metadata is read from the public track page; audio comes from the matching YouTube Music result |
+| Spotify | ✅ Tracks, playlists and albums | Metadata is read from the public pages; audio comes from the matching YouTube Music result |
 | TikTok | ✅ | |
 | SoundCloud | ✅ | Except the licensed catalogue, which is DRM protected and refused |
 | Instagram | ⚠️ Needs `COOKIES_PATH` | Instagram serves media only to a signed-in session; supply one and it works |
-| Spotify playlists / albums | ❌ Not supported | [#171](https://github.com/ArgonFetch/ArgonFetch/issues/171) |
-| Playlists generally | ❌ Not supported | [#76](https://github.com/ArgonFetch/ArgonFetch/issues/76) |
+| Playlists | ✅ Any source | Resolved as a collection; download them individually or the whole list as one zip |
 
 Downloads carry the title and artist: in the filename always, and written into the file
 itself when it is converted to MP3. A pass-through download is served byte for byte, so it
@@ -160,7 +159,6 @@ ignored. Without the variable, fetches go out from the server's own IP as before
 
 ArgonFetch no longer ships a database. Delete the `postgres` service, its
 `postgres_data` volume and the `POSTGRES_*` and
-`ConnectionStrings__ArgonFetchDatabase` variables from your `.env`, then add the
 `ConnectionStrings__ArgonFetchDatabase` variables from your `.env`. Nothing needs
 migrating — ArgonFetch keeps no persistent state at all.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -53,4 +53,4 @@ from a broken version.
 - [**Self-hosting**](/self-host) - run it with `docker compose`.
 - [**Configuration**](/configuration) - every environment variable, including proxy rotation.
 - [**Usage**](/usage) - the web UI and the API, end to end.
-- [**Developer setup**](/dev-setup) - local dev, migrations, tests.
+- [**Developer setup**](/dev-setup) - local dev, tests, and how the projects fit together.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -11,12 +11,11 @@ it is worth trying, but is not something we chase when it breaks.
 | Platform | Status | Notes |
 |---|---|---|
 | YouTube | ✅ Video and audio | Muxes separate video/audio streams when no pre-muxed format exists |
-| Spotify | ✅ Single tracks | Metadata is read from the public track page; audio comes from the matching YouTube Music result |
+| Spotify | ✅ Tracks, playlists and albums | Metadata is read from the public pages; audio comes from the matching YouTube Music result |
 | TikTok | ✅ | |
 | SoundCloud | ✅ | Except the licensed catalogue, which is DRM protected and refused - see [below](#drm-protected-tracks) |
-| Instagram | ❌ Needs a signed-in session | Instagram serves media only to logged-in accounts, and ArgonFetch has no way to supply credentials |
-| Spotify playlists / albums | ❌ Not supported | [#171](https://github.com/ArgonFetch/ArgonFetch/issues/171) |
-| Playlists generally | ❌ Not supported | [#76](https://github.com/ArgonFetch/ArgonFetch/issues/76) |
+| Instagram | ⚠️ Needs a signed-in session | Instagram serves media only to logged-in accounts. Point [`COOKIES_PATH`](/configuration) at an exported session and it works |
+| Playlists | ✅ Any source | Resolved as a collection; download the tracks individually or the whole list as one zip |
 
 ## Spotify without an API key
 
@@ -24,7 +23,9 @@ Spotify links do not need credentials. ArgonFetch reads the title, artist and co
 public track page, then finds the matching result on YouTube Music and streams the audio from
 there. There is no developer app to register and no secret to rotate.
 
-This is also why only single tracks work: playlists and albums need the Spotify API proper.
+Playlists and albums work the same way. The track list is read through the same API the
+Spotify web player uses, which needs no credentials either, and each track is then matched on
+YouTube Music like a single one.
 
 ## DRM protected tracks
 


### PR DESCRIPTION
## Type of Change
- [x] Documentation update

## Description

A sweep of the docs after #211, #213 and #216.

**The endpoint reference was already clean.** `openapi.json` carries exactly the six live paths,
and the `docs/operations/[operationId].md` pages are generated from it, so the removed
`GetRequestCount` page went with it. No stale `DATA_PATH`, `request-counter`, `dotnet ef`,
`compose.dev.yml` or `scripts/` references remain anywhere.

Four things were wrong:

**1. A mangled paragraph in `README.md`.** My edit in #213 half-replaced a sentence and left the
tail of the old one, so the upgrade note told people to add a variable it had just told them to
delete. `docs/self-host.md` has the same section and was already correct.

**2. `docs/intro.md` pointed at migrations** that no longer exist.

**3. Both platform tables said playlists were unsupported.** They carried
`Spotify playlists / albums ❌ Not supported #171` and `Playlists generally ❌ Not supported #76`.
Both issues are closed and both features shipped — #206 reads whole Spotify playlists, #208 reads
playlists from any source and zips a collection. `GetMediaQuery` routes `ContentType.Playlist`
and `ContentType.SpotifyAlbum` to `HandleSpotifyCollection`; `SpotifyWebPlayerClient` pages
through a full playlist. `platforms.md` went further and explained at length why playlists
*could not* work.

**4. `docs/platforms.md` was behind on Instagram**, still saying there was no way to supply
credentials. #205 added `COOKIES_PATH` and the README table already reflected it.

Items 3 and 4 predate the database work — documentation that was not updated when the features
landed.

## Testing

Documentation only; no code touched. Verified against the source rather than the issue titles:
`MediaContentIdentifierService` classifies `playlist` and `album` Spotify URLs,
`GetMediaQuery:107` routes both to `HandleSpotifyCollection`, and `ToolPaths.CookiesPath` is
read by `GetMediaQuery` for the Instagram case.

Swept afterwards for references to anything removed across `README.md`, `docs/*.md`,
`.vitepress/config.ts`, `compose.yml` and the env templates — none left, and no remaining links
to #76 or #171.

## Impact

The tables now describe what ArgonFetch does. Anyone who read them and concluded playlists were
unsupported was being turned away from a feature that has shipped twice.

## Issue related to PR
- Resolves #217

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.