### PR TITLE
Answer an unknown API path with 404 rather than the web page

### DIFF
--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -202,6 +202,17 @@ app.UseRouting();
 app.UseAuthorization();
 app.UseCors();
 app.MapControllers();
+
+// An unmatched /api path is a client error, not a page. UseSpa below is terminal and answers
+// anything routing did not match with index.html, which for an API path means a caller gets
+// 200 and a page of HTML instead of a 404 - a parse error rather than a status they can act
+// on. Registered as a fallback so it is chosen only when no controller matched, and the SPA
+// middleware passes through any request that already has an endpoint, so every non-API path
+// still reaches the client router untouched.
+app.MapFallback("/api/{**path}", (HttpContext context) => Results.Problem(
+    title: "Not Found",
+    detail: $"No endpoint matches {context.Request.Path}.",
+    statusCode: StatusCodes.Status404NotFound));
 #endregion
 
 #region SPA Configuration


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description

Any `/api/*` path matching no controller was answered with the Angular `index.html` and a `200`.
`app.UseSpa(...)` is terminal middleware: it serves the SPA for anything routing did not match,
and does not care whether the path looks like an API.

That is correct for `/downloads/whatever` — an Angular deep link has to reach the client router
— and wrong for `/api/*`, which has no client-side route and can only ever be a mistake. A
caller asking for a misspelled or removed endpoint got `200 OK` and a page of HTML, so anything
deserializing the response saw a parse error rather than a status it could act on, and a health
check pointed at an API path passed no matter what. It is also how I nearly convinced myself the
counter endpoint removed in #213 was still alive, while verifying #220.

The fix is a fallback scoped to `/api/{**path}`. Routing picks it only when no controller
matched, and the SPA middleware passes through any request that already has an endpoint
selected, so every non-API path still reaches the client router untouched.

Only production was affected — Development never registers `UseSpa`, so those paths already
404ed, just without a body. Both now answer the same `ProblemDetails`.

## Testing

`dotnet build` clean, `dotnet test` 118 passing.

The behaviour only exists in production with the SPA present, so I built the image and ran the
container:

| Request | Before | After |
|---|---|---|
| `/api/Totally/Bogus` | `200 text/html` | `404 application/problem+json` |
| `/api/App/requests` (removed in #213) | `200 text/html` | `404 application/problem+json` |
| `/api/App` | `200 application/json` | `200 application/json` |
| `/` | `200 text/html` | `200 text/html` |
| `/some/angular/deep/link` | `200 text/html` | `200 text/html` |

The last row is the one that mattered — SPA deep links still resolve, so the client router is
unaffected. `GET /api/Fetch/GetResource` against a YouTube URL still returns `200` with resolved
renditions.

Body of an unmatched API path:

```json
{"type":"https://tools.ietf.org/html/rfc9110#section-15.5.5","title":"Not Found","status":404,
 "detail":"No endpoint matches /api/Totally/Bogus."}
```

## Impact

A client that was silently receiving HTML now receives a 404 it can handle. Anything that was
relying on the old `200` was relying on a bug. No change to the SPA, and no route added or
removed, so the OpenAPI schema and the generated client are untouched.

## Issue related to PR
- Resolves #221

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.