### PR TITLE
Add a plugin system, and make Spotify and TikTok the first two plugins

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,79 @@
+name: Publish ArgonFetch.Abstractions
+
+# Tagged separately from the application. The contract is what plugins in other people's
+# repositories compile against, so it versions on its own schedule - most application releases
+# change nothing a plugin can see, and republishing an identical package on every one of them
+# would say otherwise.
+on:
+  push:
+    tags:
+      - 'abstractions-v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish, e.g. 1.0.0 or 1.1.0-preview.1'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Pack and publish to nuget.org
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Trusted publishing exchanges this for a short-lived key, so there is no API key stored
+      # anywhere to leak or to remember to rotate.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            RAW_TAG="${{ github.ref_name }}"
+            VERSION="${RAW_TAG#abstractions-v}"
+          fi
+
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::'$VERSION' is not a semantic version"
+            exit 1
+          fi
+
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing ArgonFetch.Abstractions $VERSION"
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # The contract compiles on its own - it references no other project in this repository,
+      # which is the point of it. Building only this project keeps the check honest.
+      - name: Build
+        run: dotnet build src/ArgonFetch.Abstractions/ArgonFetch.Abstractions.csproj -c Release
+
+      - name: Pack
+        run: >
+          dotnet pack src/ArgonFetch.Abstractions/ArgonFetch.Abstractions.csproj
+          -c Release
+          --no-build
+          -p:Version=${{ steps.version.outputs.VERSION }}
+          -o artifacts
+
+      - name: Authenticate to NuGet
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: PianoNic
+
+      - name: Push
+        run: >
+          dotnet nuget push artifacts/*.nupkg
+          --source https://api.nuget.org/v3/index.json
+          --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -415,3 +415,6 @@ docs/.vitepress/cache/
 # took them, not part of the project - a stray `git add -A` swept a megabyte of them into
 # the history once already. (.playwright-mcp/ above covers the ones that land in its folder.)
 /*.png
+
+# Plugins installed at runtime, not source.
+/src/ArgonFetch.API/plugins/

--- a/ArgonFetch.slnx
+++ b/ArgonFetch.slnx
@@ -1,5 +1,6 @@
 ﻿<Solution>
   <Project Path="src/ArgonFetch.API/ArgonFetch.API.csproj" />
+  <Project Path="src/ArgonFetch.Abstractions/ArgonFetch.Abstractions.csproj" />
   <Project Path="src/ArgonFetch.Application/ArgonFetch.Application.csproj" />
   <Project Path="src/ArgonFetch.Infrastructure/ArgonFetch.Infrastructure.csproj" />
   <Project Path="src/ArgonFetch.Tests/ArgonFetch.Tests.csproj" />

--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -125,6 +125,34 @@ builder.Services.AddSingleton<ArgonFetch.Application.Services.IProxyPool>(sp =>
 #region Validation
 // Register FluentValidation
 builder.Services.AddFluentValidationAutoValidation();
+#region Plugins
+// Read as desired state: what the configuration lists is installed, what it does not is removed.
+var pluginOptions = builder.Configuration
+    .GetSection(ArgonFetch.Application.Plugins.PluginOptions.SectionName)
+    .Get<ArgonFetch.Application.Plugins.PluginOptions>() ?? new ArgonFetch.Application.Plugins.PluginOptions();
+
+builder.Services.AddSingleton(pluginOptions);
+builder.Services.AddSingleton<ArgonFetch.Application.Plugins.PluginInstaller>();
+builder.Services.AddSingleton<ArgonFetch.Application.Plugins.PluginLoader>();
+builder.Services.AddSingleton<ArgonFetch.Application.Plugins.IProviderContextFactory,
+    ArgonFetch.Application.Plugins.ProviderContextFactory>();
+
+// Loaded once. Providers are asked on every request, so building them per request would pay
+// reflection over and over for an answer that cannot change while the process is running.
+builder.Services.AddSingleton<ArgonFetch.Application.Plugins.IProviderRegistry>(serviceProvider =>
+{
+    var loader = serviceProvider.GetRequiredService<ArgonFetch.Application.Plugins.PluginLoader>();
+    var environment = serviceProvider.GetRequiredService<IWebHostEnvironment>();
+    var root = Path.IsPathRooted(pluginOptions.Path)
+        ? pluginOptions.Path
+        : Path.Combine(environment.ContentRootPath, pluginOptions.Path);
+
+    return new ArgonFetch.Application.Plugins.ProviderRegistry(
+        loader.Load(root, pluginOptions.Install),
+        serviceProvider.GetRequiredService<ILogger<ArgonFetch.Application.Plugins.ProviderRegistry>>());
+});
+#endregion
+
 builder.Services.AddValidatorsFromAssemblyContaining<GetMediaQueryValidator>();
 builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
 #endregion
@@ -164,6 +192,24 @@ var app = builder.Build();
 
 #region Startup Diagnostics
 var startupLogger = app.Services.GetRequiredService<ILogger<Program>>();
+
+// Before the registry is ever resolved, so what is on disk is what was asked for by the time
+// anything looks. Deliberately at startup and never during a request: software that installs
+// itself halfway through a download is not something anyone wants to debug.
+{
+    var pluginRoot = Path.IsPathRooted(pluginOptions.Path)
+        ? pluginOptions.Path
+        : Path.Combine(app.Environment.ContentRootPath, pluginOptions.Path);
+
+    await app.Services.GetRequiredService<ArgonFetch.Application.Plugins.PluginInstaller>()
+        .InstallAsync(pluginOptions, pluginRoot);
+
+    var registry = app.Services.GetRequiredService<ArgonFetch.Application.Plugins.IProviderRegistry>();
+
+    startupLogger.LogInformation("Plugins: {Count} loaded{Names}",
+        registry.Plugins.Count,
+        registry.Plugins.Count == 0 ? string.Empty : " - " + string.Join(", ", registry.Plugins.Select(p => $"{p.Id} {p.Version}")));
+}
 
 if (app.Environment.IsProduction() && corsUsesDevelopmentDefault)
 {

--- a/src/ArgonFetch.API/appsettings.Development.json
+++ b/src/ArgonFetch.API/appsettings.Development.json
@@ -4,5 +4,12 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Plugins": {
+    "Repositories": [],
+    "Install": [
+      "spotify",
+      "tiktok"
+    ]
   }
 }

--- a/src/ArgonFetch.Abstractions/ArgonFetch.Abstractions.csproj
+++ b/src/ArgonFetch.Abstractions/ArgonFetch.Abstractions.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <!--
+      Everything a plugin author compiles against, and nothing else. Kept deliberately thin: a
+      type that appears here is a promise, and a promise made to code living in somebody else's
+      repository is expensive to take back.
+    -->
+    <PackageId>ArgonFetch.Abstractions</PackageId>
+    <Version>1.0.0-preview.1</Version>
+    <Authors>ArgonFetch</Authors>
+    <Description>Contract for writing ArgonFetch source plugins.</Description>
+    <PackageProjectUrl>https://github.com/ArgonFetch/ArgonFetch</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/ArgonFetch/ArgonFetch</RepositoryUrl>
+
+    <!--
+      MIT while the application around it is GPL-3.0. A plugin has to reference this to exist,
+      so a copyleft licence here would decide the licence of every plugin anyone ever writes.
+    -->
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE" Pack="true" PackagePath="" />
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      The only dependencies allowed here, and only because every .NET application already has
+      them: a plugin that needs a logger should not be handed a second logging abstraction to
+      learn. Nothing else may be added without the same argument.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/ArgonFetch.Abstractions/ArgonFetch.Abstractions.csproj
+++ b/src/ArgonFetch.Abstractions/ArgonFetch.Abstractions.csproj
@@ -11,7 +11,7 @@
       repository is expensive to take back.
     -->
     <PackageId>ArgonFetch.Abstractions</PackageId>
-    <Version>1.0.0-preview.1</Version>
+    <Version>1.0.0-preview.2</Version>
     <Authors>ArgonFetch</Authors>
     <Description>Contract for writing ArgonFetch source plugins.</Description>
     <PackageProjectUrl>https://github.com/ArgonFetch/ArgonFetch</PackageProjectUrl>

--- a/src/ArgonFetch.Abstractions/ArgonFetchPluginAttribute.cs
+++ b/src/ArgonFetch.Abstractions/ArgonFetchPluginAttribute.cs
@@ -1,0 +1,36 @@
+namespace ArgonFetch.Abstractions
+{
+    /// <summary>
+    /// Marks an assembly as an ArgonFetch plugin and states which contract it was built against.
+    /// <para>
+    /// Read before anything in the assembly is instantiated, so a plugin written for a contract
+    /// this host does not implement is set aside with a line in the log rather than loaded and
+    /// discovered halfway through a request.
+    /// </para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+    public sealed class ArgonFetchPluginAttribute : Attribute
+    {
+        public ArgonFetchPluginAttribute(string id, int abi)
+        {
+            Id = id;
+            Abi = abi;
+        }
+
+        /// <summary>The id this plugin is installed and configured under.</summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// Major version of ArgonFetch.Abstractions this was built against. The host implements
+        /// exactly one, and refuses anything else - a contract that changed shape is not
+        /// something to guess at.
+        /// </summary>
+        public int Abi { get; }
+
+        /// <summary>Shown to an operator choosing what to install.</summary>
+        public string? Name { get; init; }
+
+        /// <summary>The current contract, for a plugin that does not want to spell out a number.</summary>
+        public const int CurrentAbi = 1;
+    }
+}

--- a/src/ArgonFetch.Abstractions/IProviderContext.cs
+++ b/src/ArgonFetch.Abstractions/IProviderContext.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace ArgonFetch.Abstractions
+{
+    /// <summary>
+    /// What the host lends a provider.
+    /// <para>
+    /// Capabilities, never the container. Handing over a service provider would make every type
+    /// the host happens to register part of this contract, and the first plugin to reach for one
+    /// would freeze it there.
+    /// </para>
+    /// </summary>
+    public interface IProviderContext
+    {
+        /// <summary>
+        /// A client for talking to the source.
+        /// </summary>
+        /// <param name="rotateProxy">
+        /// Whether to go through the next proxy in the pool. Sources that count requests per
+        /// address want this; one that hands out an address signed for the caller does not,
+        /// because the download that follows has to come from the same place.
+        /// </param>
+        HttpClient CreateHttpClient(bool rotateProxy = true);
+
+        /// <summary>
+        /// Shared with the rest of the application, so a plugin must key entries with something
+        /// of its own. <see cref="CacheKey"/> does that.
+        /// </summary>
+        IMemoryCache Cache { get; }
+
+        /// <summary>Named for the plugin, so its lines are attributable in a shared log.</summary>
+        ILogger Logger { get; }
+
+        /// <summary>
+        /// Settings the operator wrote for this plugin, from the configuration section named
+        /// after it. Empty when none were given - a plugin that needs one has to say so itself.
+        /// </summary>
+        IReadOnlyDictionary<string, string?> Settings { get; }
+
+        /// <summary>
+        /// What the fetch engine can say about a link without downloading it.
+        /// <para>
+        /// For choosing between candidates: a provider that has found several possible matches
+        /// for a recording can ask how long each one runs and keep the one that fits. Null when
+        /// the link cannot be read at all, which is an answer rather than a fault.
+        /// </para>
+        /// <para>
+        /// The result is remembered for the length of the request, so probing a link and then
+        /// handing that same link back as a rewrite does not fetch it twice.
+        /// </para>
+        /// </summary>
+        Task<ProbeResult?> ProbeAsync(Uri url, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// A cache key belonging to this plugin, so two plugins caching "track:1" do not
+        /// overwrite each other.
+        /// </summary>
+        string CacheKey(string key);
+    }
+}

--- a/src/ArgonFetch.Abstractions/ISourceProvider.cs
+++ b/src/ArgonFetch.Abstractions/ISourceProvider.cs
@@ -21,15 +21,35 @@ namespace ArgonFetch.Abstractions
         string Id { get; }
 
         /// <summary>
-        /// Whether this provider wants the link.
+        /// Which links this provider wants, as regular expressions matched against the whole URL.
         /// <para>
-        /// Must be cheap, must not touch the network, and must not throw: it is asked of every
-        /// installed provider on every request, so anything expensive here is paid for by
-        /// downloads that have nothing to do with this plugin. That is the whole reason it is
-        /// not asynchronous - an awaitable signature invites a request nobody meant to make.
+        /// Declared rather than decided in code so the host can do the matching: it compiles each
+        /// one once instead of on every request, applies a time limit so a pattern that backtracks
+        /// badly cannot hang a download, and can say plainly which plugin claimed what. It also
+        /// means the usual plugin writes one line here and no matching code at all.
+        /// </para>
+        /// <para>
+        /// Matched without regard to case. A pattern that does not compile is skipped with a line
+        /// in the log rather than taking the plugin down with it.
         /// </para>
         /// </summary>
-        bool CanHandle(Uri url);
+        /// <example><c>[@"^https?://([\w-]+\.)*spotify\.com/"]</c></example>
+        IReadOnlyList<string> UrlPatterns { get; }
+
+        /// <summary>
+        /// A second opinion, once a pattern has already matched.
+        /// <para>
+        /// Almost no provider needs this - the patterns are usually the whole answer, and the
+        /// default accepts whatever they matched. Override it when the URL alone decides
+        /// something a regular expression should not be asked to express.
+        /// </para>
+        /// <para>
+        /// Must be cheap, must not touch the network, and must not throw: it is asked on every
+        /// request for a link this provider claimed. That is why it is not asynchronous - an
+        /// awaitable signature invites a request nobody meant to make.
+        /// </para>
+        /// </summary>
+        bool CanHandle(Uri url) => true;
 
         /// <summary>
         /// What should happen to the link. See <see cref="ProviderOutcome"/> for the four answers.

--- a/src/ArgonFetch.Abstractions/ISourceProvider.cs
+++ b/src/ArgonFetch.Abstractions/ISourceProvider.cs
@@ -1,0 +1,75 @@
+namespace ArgonFetch.Abstractions
+{
+    /// <summary>
+    /// A source ArgonFetch does not already know how to fetch.
+    /// <para>
+    /// yt-dlp is what fetches things the ordinary way, and most links need nothing more than
+    /// that. A provider exists for the links that do: one that has to be turned into a different
+    /// link before anything can be downloaded, one that lists a collection, or one that a
+    /// separate piece of code fetches entirely on its own.
+    /// </para>
+    /// </summary>
+    public interface ISourceProvider
+    {
+        /// <summary>
+        /// Stable name for this provider, matching the id it is installed under - "spotify".
+        /// <para>
+        /// It is how an operator asks for the plugin and how conflicts between two providers are
+        /// settled, so renaming one is a breaking change to somebody's configuration.
+        /// </para>
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// Whether this provider wants the link.
+        /// <para>
+        /// Must be cheap, must not touch the network, and must not throw: it is asked of every
+        /// installed provider on every request, so anything expensive here is paid for by
+        /// downloads that have nothing to do with this plugin. That is the whole reason it is
+        /// not asynchronous - an awaitable signature invites a request nobody meant to make.
+        /// </para>
+        /// </summary>
+        bool CanHandle(Uri url);
+
+        /// <summary>
+        /// What should happen to the link. See <see cref="ProviderOutcome"/> for the four answers.
+        /// </summary>
+        Task<ProviderOutcome> PrepareAsync(Uri url, IProviderContext context, CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Adjusts how yt-dlp is invoked, for sources that are fetched the ordinary way but need
+    /// something said first - a session to prove who is asking, a particular container.
+    /// <para>
+    /// Separate from <see cref="ISourceProvider"/> because it composes: several hooks may apply
+    /// to one fetch, where exactly one provider ever handles a link.
+    /// </para>
+    /// </summary>
+    public interface IFetchOptionsHook
+    {
+        /// <summary>
+        /// Called before every fetch, for every link. Change only what this hook is for and
+        /// leave the rest alone - the next hook in line is looking at the same object.
+        /// </summary>
+        void Configure(IFetchOptions options, Uri url);
+    }
+
+    /// <summary>
+    /// The parts of a yt-dlp invocation a plugin may change. Deliberately not the whole option
+    /// set: everything exposed here is something the host promises to keep meaning the same.
+    /// </summary>
+    public interface IFetchOptions
+    {
+        /// <summary>Path to a cookies file, for a source that serves nothing to strangers.</summary>
+        string? CookiesPath { get; set; }
+
+        /// <summary>Proxy to fetch through. Already set from the rotating pool; replacing it opts out of that.</summary>
+        string? Proxy { get; set; }
+
+        /// <summary>yt-dlp format selector, when the default pick is wrong for a source.</summary>
+        string? Format { get; set; }
+
+        /// <summary>An <c>--extractor-args</c> entry, e.g. <c>("youtube", "player_client=web")</c>.</summary>
+        void SetExtractorArgument(string extractor, string argument);
+    }
+}

--- a/src/ArgonFetch.Abstractions/LICENSE
+++ b/src/ArgonFetch.Abstractions/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ArgonFetch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/ArgonFetch.Abstractions/ProviderOutcome.cs
+++ b/src/ArgonFetch.Abstractions/ProviderOutcome.cs
@@ -1,0 +1,50 @@
+namespace ArgonFetch.Abstractions
+{
+    /// <summary>
+    /// What a provider decided to do with a link. There are four answers and no others.
+    /// </summary>
+    public abstract record ProviderOutcome
+    {
+        private ProviderOutcome() { }
+
+        /// <summary>
+        /// Nothing to do - let yt-dlp fetch the original link. Also the right answer when a
+        /// provider recognises the link but finds nothing special about this particular one.
+        /// </summary>
+        public static ProviderOutcome PassThrough { get; } = new PassThroughOutcome();
+
+        /// <summary>
+        /// Fetch a different link instead, and describe the result with these tags.
+        /// <para>
+        /// Spotify serves no audio anyone can download, so its provider finds the same recording
+        /// elsewhere and points the fetch at that - while keeping Spotify's own title and credit,
+        /// which are the reason the track was matched rather than merely searched for.
+        /// </para>
+        /// </summary>
+        public static ProviderOutcome Rewrite(Uri url, MediaTags tags, string? coverUrl = null) =>
+            new RewriteOutcome(url, tags, coverUrl);
+
+        /// <summary>
+        /// The link names a collection. Entries are listed, not resolved - each one is fetched
+        /// through the ordinary path when somebody actually asks for it, because resolving a
+        /// thousand of them to show a list would take the better part of an hour.
+        /// </summary>
+        public static ProviderOutcome Listing(CollectionResult collection) =>
+            new ListingOutcome(collection);
+
+        /// <summary>
+        /// The provider fetched it. yt-dlp is not run at all.
+        /// </summary>
+        public static ProviderOutcome Complete(MediaResult media) =>
+            new CompleteOutcome(media);
+
+        /// <summary>Not this provider's link after all - try the next one, then yt-dlp.</summary>
+        public static ProviderOutcome Declined { get; } = new DeclinedOutcome();
+
+        public sealed record PassThroughOutcome : ProviderOutcome;
+        public sealed record DeclinedOutcome : ProviderOutcome;
+        public sealed record RewriteOutcome(Uri Url, MediaTags Tags, string? CoverUrl) : ProviderOutcome;
+        public sealed record ListingOutcome(CollectionResult Collection) : ProviderOutcome;
+        public sealed record CompleteOutcome(MediaResult Media) : ProviderOutcome;
+    }
+}

--- a/src/ArgonFetch.Abstractions/README.md
+++ b/src/ArgonFetch.Abstractions/README.md
@@ -1,0 +1,45 @@
+# ArgonFetch.Abstractions
+
+Everything you need to write an ArgonFetch source plugin, and nothing else.
+
+yt-dlp is what fetches things the ordinary way. A plugin exists for links that need something
+else first: one that has to become a different link before anything can be downloaded, one that
+lists a collection, or one that a separate piece of code fetches on its own.
+
+```csharp
+[assembly: ArgonFetchPlugin("example", ArgonFetchPluginAttribute.CurrentAbi, Name = "Example")]
+
+public sealed class ExampleProvider : ISourceProvider
+{
+    public string Id => "example";
+
+    public bool CanHandle(Uri url) => url.Host.EndsWith("example.com");
+
+    public async Task<ProviderOutcome> PrepareAsync(Uri url, IProviderContext ctx, CancellationToken ct)
+    {
+        var real = await FindRealUrl(url, ctx, ct);
+
+        return ProviderOutcome.Rewrite(real, new MediaTags("Title", "Artist"));
+    }
+}
+```
+
+## Reference this without shipping it
+
+```xml
+<PackageReference Include="ArgonFetch.Abstractions" Version="1.0.0" ExcludeAssets="runtime" />
+```
+
+`ExcludeAssets="runtime"` matters. The host loads this assembly and hands your plugin types from
+its own copy. A plugin that carries its own copy gets a second, unrelated `ISourceProvider`, and
+the load fails complaining that `ISourceProvider` cannot be cast to `ISourceProvider`.
+
+## Rules worth knowing before you write one
+
+- `CanHandle` is asked of every installed plugin on every request. Keep it to inspecting the URL:
+  no network, no throwing, no waiting.
+- Return raw addresses in `MediaStream`. Caching them, hiding them behind keys and building the
+  URLs a client sees is the host's business, and it changes.
+- Cache through `IProviderContext.CacheKey`, never a bare string - the cache is shared.
+
+MIT licensed, so what you write with it is yours to license as you please.

--- a/src/ArgonFetch.Abstractions/Results.cs
+++ b/src/ArgonFetch.Abstractions/Results.cs
@@ -1,0 +1,75 @@
+namespace ArgonFetch.Abstractions
+{
+    /// <summary>
+    /// What a downloaded file should say it is. Carried from whatever identified the media to
+    /// whatever serves it.
+    /// </summary>
+    public sealed record MediaTags(string? Title, string? Artist);
+
+    /// <summary>
+    /// A collection, as a list of links and what little is known about each.
+    /// </summary>
+    public sealed record CollectionResult(
+        string? Title,
+        string? Author,
+        string? CoverUrl,
+        IReadOnlyList<CollectionEntry> Items)
+    {
+        /// <summary>
+        /// Whether the source is known to have sent only part of the list. Reported rather than
+        /// hidden: a listing that quietly stops at a hundred looks exactly like a hundred-entry
+        /// collection, and nobody notices what is missing.
+        /// </summary>
+        public bool MayBeTruncated { get; init; }
+    }
+
+    /// <summary>
+    /// One entry of a collection. Deliberately not resolved - the link is enough, and following
+    /// it is what happens when somebody picks this entry.
+    /// </summary>
+    public sealed record CollectionEntry(Uri Url, string Title, string? Author = null, string? CoverUrl = null);
+
+    /// <summary>
+    /// Media a provider fetched by itself.
+    /// </summary>
+    public sealed record MediaResult(
+        string Title,
+        string? Author,
+        string? CoverUrl,
+        IReadOnlyList<MediaStream> Streams);
+
+    /// <summary>
+    /// One downloadable stream, as the source serves it.
+    /// <para>
+    /// A plain address and what is known about it, nothing more. Caching it, hiding it behind a
+    /// key and building the URL a client is given are all the host's business - a plugin that
+    /// did any of that would be coupled to how the host serves bytes, which changes.
+    /// </para>
+    /// </summary>
+    public sealed record MediaStream(Uri Url, bool IsAudio)
+    {
+        /// <summary>Shown to whoever is choosing, e.g. "1080p" or "128 kbps".</summary>
+        public string? Label { get; init; }
+
+        /// <summary>Media type of the bytes at <see cref="Url"/>, where the source declares one.</summary>
+        public string? MimeType { get; init; }
+
+        /// <summary>Extension the file should be saved as, including the dot.</summary>
+        public string? FileExtension { get; init; }
+
+        /// <summary>Transfer size where the source reports one; it is what tells a reader how long this will take.</summary>
+        public long? SizeBytes { get; init; }
+
+        /// <summary>
+        /// Proxy this address was obtained through, when it was. Sources commonly sign an address
+        /// for the address that asked for it, so fetching it from anywhere else is refused.
+        /// </summary>
+        public string? Proxy { get; init; }
+    }
+
+    /// <summary>
+    /// The little that can be learned about a link without downloading it. Enough to tell one
+    /// candidate recording from another, which is what it is for.
+    /// </summary>
+    public sealed record ProbeResult(string? Title, string? Uploader, double? DurationSeconds);
+}

--- a/src/ArgonFetch.Application/ArgonFetch.Application.csproj
+++ b/src/ArgonFetch.Application/ArgonFetch.Application.csproj
@@ -32,4 +32,8 @@
     <PackageReference Include="YouTubeMusicAPI" Version="3.0.10" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\ArgonFetch.Abstractions\ArgonFetch.Abstractions.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/ArgonFetch.Application/Plugins/PluginInstaller.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginInstaller.cs
@@ -1,0 +1,235 @@
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text.Json;
+using ArgonFetch.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace ArgonFetch.Application.Plugins
+{
+    /// <summary>
+    /// Makes the plugins folder match what was asked for.
+    /// <para>
+    /// Runs once at startup and never during a request: a download that quietly installs software
+    /// halfway through is not something anyone wants to debug.
+    /// </para>
+    /// </summary>
+    public class PluginInstaller
+    {
+        private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<PluginInstaller> _logger;
+
+        public PluginInstaller(IHttpClientFactory httpClientFactory, ILogger<PluginInstaller> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+        }
+
+        public async Task InstallAsync(PluginOptions options, string root, CancellationToken cancellationToken = default)
+        {
+            Directory.CreateDirectory(root);
+
+            var wanted = options.Install
+                .Select(Parse)
+                .Where(request => request is not null)
+                .Select(request => request!.Value)
+                .ToList();
+
+            Prune(root, wanted.Select(w => w.Id).ToHashSet(StringComparer.OrdinalIgnoreCase));
+
+            if (wanted.Count == 0)
+                return;
+
+            var index = await ReadIndexesAsync(options.Repositories, cancellationToken);
+
+            foreach (var (id, version) in wanted)
+            {
+                try
+                {
+                    await InstallOneAsync(root, id, version, index, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    // A plugin that cannot be installed must not stop the application: the rest
+                    // of it still works, and refusing to start would take a whole downloader
+                    // offline because one source's repository is having a bad morning.
+                    _logger.LogError(ex, "Could not install the {Id} plugin", id);
+                }
+            }
+        }
+
+        private async Task InstallOneAsync(
+            string root,
+            string id,
+            string? version,
+            IReadOnlyDictionary<string, List<(PluginIndexEntry Entry, Uri BaseUri)>> index,
+            CancellationToken cancellationToken)
+        {
+            var installed = InstalledVersion(root, id);
+
+            if (!index.TryGetValue(id, out var candidates))
+            {
+                // Already present and no index to check it against is a working setup, not a
+                // failure - which is what keeps an unreachable repository from taking the
+                // application down with it.
+                if (installed is not null)
+                {
+                    _logger.LogInformation("Keeping the {Id} plugin at {Version}; no repository listed it", id, installed);
+                    return;
+                }
+
+                _logger.LogWarning("No repository offers a plugin called {Id}", id);
+                return;
+            }
+
+            var compatible = candidates
+                .Where(c => c.Entry.Abi == ArgonFetchPluginAttribute.CurrentAbi)
+                .Where(c => version is null || string.Equals(c.Entry.Version, version, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(c => ParseVersion(c.Entry.Version))
+                .ToList();
+
+            if (compatible.Count == 0)
+            {
+                _logger.LogWarning(
+                    "No build of {Id} matches{Pinned} and contract {Abi}",
+                    id, version is null ? string.Empty : $" version {version}", ArgonFetchPluginAttribute.CurrentAbi);
+                return;
+            }
+
+            var (entry, baseUri) = compatible[0];
+
+            if (installed == entry.Version)
+                return;
+
+            _logger.LogInformation("Installing {Id} {Version}", id, entry.Version);
+
+            await DownloadAsync(root, entry, baseUri, cancellationToken);
+        }
+
+        private async Task DownloadAsync(string root, PluginIndexEntry entry, Uri baseUri, CancellationToken cancellationToken)
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+            var address = new Uri(baseUri, entry.File);
+
+            var bytes = await httpClient.GetByteArrayAsync(address, cancellationToken);
+            var digest = Convert.ToHexString(SHA256.HashData(bytes));
+
+            if (!digest.Equals(entry.Sha256, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException($"{address} did not hash to what the index said it would.");
+
+            var folder = Path.Combine(root, entry.Id);
+
+            // Replaced rather than merged: leaving an older build's files behind is how a plugin
+            // ends up loading half of one version and half of another.
+            if (Directory.Exists(folder))
+                Directory.Delete(folder, recursive: true);
+
+            Directory.CreateDirectory(folder);
+
+            using var archive = new ZipArchive(new MemoryStream(bytes), ZipArchiveMode.Read);
+            archive.ExtractToDirectory(folder, overwriteFiles: true);
+
+            await File.WriteAllTextAsync(Path.Combine(folder, ".version"), entry.Version, cancellationToken);
+        }
+
+        private async Task<IReadOnlyDictionary<string, List<(PluginIndexEntry, Uri)>>> ReadIndexesAsync(
+            IEnumerable<string> repositories,
+            CancellationToken cancellationToken)
+        {
+            var index = new Dictionary<string, List<(PluginIndexEntry, Uri)>>(StringComparer.OrdinalIgnoreCase);
+            var httpClient = _httpClientFactory.CreateClient();
+
+            foreach (var repository in repositories)
+            {
+                if (!Uri.TryCreate(repository, UriKind.Absolute, out var uri))
+                {
+                    _logger.LogWarning("Skipping plugin repository {Repository}: not a URL", repository);
+                    continue;
+                }
+
+                try
+                {
+                    var body = await httpClient.GetStringAsync(uri, cancellationToken);
+                    var entries = JsonSerializer.Deserialize<List<PluginIndexEntry>>(body, Json) ?? [];
+
+                    foreach (var entry in entries)
+                    {
+                        if (string.IsNullOrWhiteSpace(entry.Id))
+                            continue;
+
+                        // Two repositories offering the same id makes the configuration
+                        // ambiguous - "spotify" would mean different software depending on
+                        // which repository answered first. The one listed earlier wins, and
+                        // the clash is said out loud rather than resolved quietly.
+                        if (index.TryGetValue(entry.Id, out var existing) && existing[0].Item2 != uri)
+                        {
+                            _logger.LogWarning(
+                                "{Repository} also offers a plugin called {Id}; keeping the one from {Winner}",
+                                uri, entry.Id, existing[0].Item2);
+                            continue;
+                        }
+
+                        if (!index.TryGetValue(entry.Id, out var list))
+                            index[entry.Id] = list = [];
+
+                        list.Add((entry, uri));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Could not read the plugin repository at {Repository}", uri);
+                }
+            }
+
+            return index;
+        }
+
+        /// <summary>Removes anything installed that is no longer asked for.</summary>
+        private void Prune(string root, HashSet<string> wanted)
+        {
+            foreach (var folder in Directory.GetDirectories(root))
+            {
+                var id = Path.GetFileName(folder);
+
+                if (wanted.Contains(id))
+                    continue;
+
+                _logger.LogInformation("Removing the {Id} plugin; it is no longer listed", id);
+
+                try
+                {
+                    Directory.Delete(folder, recursive: true);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Could not remove the {Id} plugin", id);
+                }
+            }
+        }
+
+        private static string? InstalledVersion(string root, string id)
+        {
+            var marker = Path.Combine(root, id, ".version");
+
+            return File.Exists(marker) ? File.ReadAllText(marker).Trim() : null;
+        }
+
+        /// <summary>Splits "spotify" or "spotify@1.2.0".</summary>
+        internal static (string Id, string? Version)? Parse(string request)
+        {
+            if (string.IsNullOrWhiteSpace(request))
+                return null;
+
+            var parts = request.Split('@', 2, StringSplitOptions.TrimEntries);
+
+            return parts.Length == 2 && parts[1].Length > 0
+                ? (parts[0], parts[1])
+                : (parts[0], null);
+        }
+
+        /// <summary>Compares as a version where possible, so 1.10.0 outranks 1.9.0.</summary>
+        private static Version ParseVersion(string version) =>
+            Version.TryParse(version.Split('-')[0], out var parsed) ? parsed : new Version(0, 0);
+    }
+}

--- a/src/ArgonFetch.Application/Plugins/PluginLoadContext.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginLoadContext.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace ArgonFetch.Application.Plugins
+{
+    /// <summary>
+    /// One plugin's own corner of the process.
+    /// <para>
+    /// A plugin brings its own dependencies, and two plugins will eventually bring different
+    /// versions of the same one. Each gets its own context so that stays their problem rather
+    /// than becoming a version conflict nobody can resolve.
+    /// </para>
+    /// <para>
+    /// The contract is the exception, and it has to be. Types have identity per context, so a
+    /// plugin loading its own copy of ArgonFetch.Abstractions would implement an
+    /// <c>ISourceProvider</c> unrelated to the one the host is looking for - and say so with a
+    /// message claiming ISourceProvider cannot be cast to ISourceProvider. It is deliberately
+    /// resolved from the host instead, which is why a plugin references the package without
+    /// shipping it.
+    /// </para>
+    /// </summary>
+    internal sealed class PluginLoadContext : AssemblyLoadContext
+    {
+        private static readonly string[] Shared =
+        [
+            "ArgonFetch.Abstractions",
+            // The two the contract itself exposes. A plugin handed an ILogger from its own copy
+            // of the abstractions could not be given the host's logger.
+            "Microsoft.Extensions.Logging.Abstractions",
+            "Microsoft.Extensions.Caching.Abstractions",
+            "Microsoft.Extensions.Primitives",
+        ];
+
+        private readonly AssemblyDependencyResolver _resolver;
+
+        public PluginLoadContext(string pluginPath)
+            // Collectible so a plugin can be unloaded; without it, replacing one means a restart.
+            : base(name: Path.GetFileNameWithoutExtension(pluginPath), isCollectible: true)
+        {
+            _resolver = new AssemblyDependencyResolver(pluginPath);
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            // Null hands the request back to the default context, which is where the host's own
+            // copy lives. Anything else the plugin brought is loaded privately below.
+            if (Shared.Contains(assemblyName.Name, StringComparer.OrdinalIgnoreCase))
+                return null;
+
+            var path = _resolver.ResolveAssemblyToPath(assemblyName);
+
+            return path is null ? null : LoadFromAssemblyPath(path);
+        }
+
+        protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+        {
+            var path = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+
+            return path is null ? IntPtr.Zero : LoadUnmanagedDllFromPath(path);
+        }
+    }
+}

--- a/src/ArgonFetch.Application/Plugins/PluginLoader.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginLoader.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.Loader;
 using ArgonFetch.Abstractions;
 using Microsoft.Extensions.Logging;
 
@@ -10,7 +11,20 @@ namespace ArgonFetch.Application.Plugins
         string? Name,
         string Version,
         IReadOnlyList<ISourceProvider> Providers,
-        IReadOnlyList<IFetchOptionsHook> Hooks);
+        IReadOnlyList<IFetchOptionsHook> Hooks)
+    {
+        /// <summary>
+        /// The context this plugin's assemblies live in, held only so that it keeps living.
+        /// <para>
+        /// A collectible context is collected once nothing refers to it, and unloading takes the
+        /// plugin's own dependencies with it - which does not show up until the plugin first
+        /// reaches for one and is told the context is already unloaded. The providers above are
+        /// not enough to keep it: they are instances, and an instance does not root the context
+        /// its type was loaded into.
+        /// </para>
+        /// </summary>
+        internal AssemblyLoadContext? Context { get; init; }
+    }
 
     /// <summary>
     /// Turns the plugins folder into objects the application can call.
@@ -126,7 +140,7 @@ namespace ArgonFetch.Application.Plugins
                     "Loaded the {Id} plugin {Version} ({Providers} provider(s), {Hooks} hook(s))",
                     manifest.Id, version, providers.Count, hooks.Count);
 
-                return new LoadedPlugin(manifest.Id, manifest.Name, version, providers, hooks);
+                return new LoadedPlugin(manifest.Id, manifest.Name, version, providers, hooks) { Context = context };
             }
 
             _logger.LogWarning("Nothing in {Folder} declares itself an ArgonFetch plugin", folder);

--- a/src/ArgonFetch.Application/Plugins/PluginLoader.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginLoader.cs
@@ -1,0 +1,167 @@
+using System.Reflection;
+using ArgonFetch.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace ArgonFetch.Application.Plugins
+{
+    /// <summary>A plugin that was loaded, and what came out of it.</summary>
+    public sealed record LoadedPlugin(
+        string Id,
+        string? Name,
+        string Version,
+        IReadOnlyList<ISourceProvider> Providers,
+        IReadOnlyList<IFetchOptionsHook> Hooks);
+
+    /// <summary>
+    /// Turns the plugins folder into objects the application can call.
+    /// </summary>
+    public class PluginLoader
+    {
+        private readonly ILogger<PluginLoader> _logger;
+
+        public PluginLoader(ILogger<PluginLoader> logger) => _logger = logger;
+
+        /// <summary>
+        /// Loads the requested plugins, in the order they were requested - which is the order
+        /// their providers are then asked in.
+        /// </summary>
+        public IReadOnlyList<LoadedPlugin> Load(string root, IEnumerable<string> install)
+        {
+            var loaded = new List<LoadedPlugin>();
+
+            if (!Directory.Exists(root))
+                return loaded;
+
+            foreach (var request in install)
+            {
+                var parsed = PluginInstaller.Parse(request);
+
+                if (parsed is null)
+                    continue;
+
+                var folder = Path.Combine(root, parsed.Value.Id);
+
+                if (!Directory.Exists(folder))
+                {
+                    _logger.LogWarning("The {Id} plugin is configured but not installed", parsed.Value.Id);
+                    continue;
+                }
+
+                try
+                {
+                    var plugin = LoadOne(folder, parsed.Value.Id);
+
+                    if (plugin is not null)
+                        loaded.Add(plugin);
+                }
+                catch (Exception ex)
+                {
+                    // One bad plugin costs its own sources and nothing else.
+                    _logger.LogError(ex, "Could not load the {Id} plugin", parsed.Value.Id);
+                }
+            }
+
+            return loaded;
+        }
+
+        private LoadedPlugin? LoadOne(string folder, string id)
+        {
+            // The assembly named after the folder, or failing that whichever one declares
+            // itself a plugin. Named first because it is the cheap answer and almost always
+            // the right one.
+            var candidates = Directory.GetFiles(folder, "*.dll")
+                .OrderByDescending(path => Path.GetFileNameWithoutExtension(path)
+                    .EndsWith(id, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            foreach (var path in candidates)
+            {
+                var context = new PluginLoadContext(path);
+                Assembly assembly;
+
+                try
+                {
+                    assembly = context.LoadFromAssemblyPath(path);
+                }
+                catch (BadImageFormatException)
+                {
+                    // A native library sitting beside the managed ones.
+                    context.Unload();
+                    continue;
+                }
+
+                var manifest = assembly.GetCustomAttribute<ArgonFetchPluginAttribute>();
+
+                if (manifest is null)
+                {
+                    context.Unload();
+                    continue;
+                }
+
+                if (manifest.Abi != ArgonFetchPluginAttribute.CurrentAbi)
+                {
+                    // Set aside before anything in it runs. A contract that changed shape is not
+                    // something to find out about halfway through somebody's download.
+                    _logger.LogWarning(
+                        "The {Id} plugin was built for contract {Theirs}; this build implements {Ours}",
+                        manifest.Id, manifest.Abi, ArgonFetchPluginAttribute.CurrentAbi);
+
+                    context.Unload();
+                    return null;
+                }
+
+                var providers = Instantiate<ISourceProvider>(assembly);
+                var hooks = Instantiate<IFetchOptionsHook>(assembly);
+
+                if (providers.Count == 0 && hooks.Count == 0)
+                {
+                    _logger.LogWarning("The {Id} plugin declares itself one but offers nothing", manifest.Id);
+                    context.Unload();
+                    return null;
+                }
+
+                var version = ReadVersion(folder);
+
+                _logger.LogInformation(
+                    "Loaded the {Id} plugin {Version} ({Providers} provider(s), {Hooks} hook(s))",
+                    manifest.Id, version, providers.Count, hooks.Count);
+
+                return new LoadedPlugin(manifest.Id, manifest.Name, version, providers, hooks);
+            }
+
+            _logger.LogWarning("Nothing in {Folder} declares itself an ArgonFetch plugin", folder);
+            return null;
+        }
+
+        private List<T> Instantiate<T>(Assembly assembly) where T : class
+        {
+            var made = new List<T>();
+
+            foreach (var type in assembly.GetExportedTypes())
+            {
+                if (type.IsAbstract || type.IsInterface || !typeof(T).IsAssignableFrom(type))
+                    continue;
+
+                // Parameterless only, as the manifest is read before any of the host's services
+                // could be handed over. What a plugin needs arrives with each call instead.
+                if (type.GetConstructor(Type.EmptyTypes) is null)
+                {
+                    _logger.LogWarning("{Type} has no parameterless constructor and was skipped", type.FullName);
+                    continue;
+                }
+
+                if (Activator.CreateInstance(type) is T instance)
+                    made.Add(instance);
+            }
+
+            return made;
+        }
+
+        private static string ReadVersion(string folder)
+        {
+            var marker = Path.Combine(folder, ".version");
+
+            return File.Exists(marker) ? File.ReadAllText(marker).Trim() : "unknown";
+        }
+    }
+}

--- a/src/ArgonFetch.Application/Plugins/PluginOptions.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginOptions.cs
@@ -1,0 +1,67 @@
+namespace ArgonFetch.Application.Plugins
+{
+    /// <summary>
+    /// Which plugins an operator wants, and where to get them.
+    /// <para>
+    /// Read as desired state rather than as instructions: what is listed is installed, what is
+    /// not is removed. A list that says what should be true is one you can read and know what
+    /// the machine is running; a list of things that were once installed is not.
+    /// </para>
+    /// </summary>
+    public class PluginOptions
+    {
+        public const string SectionName = "Plugins";
+
+        /// <summary>
+        /// Indexes to look in, in order. Each is the URL of an index.json listing what that
+        /// repository publishes.
+        /// </summary>
+        public List<string> Repositories { get; set; } = [];
+
+        /// <summary>
+        /// Plugins to have installed, as "id" for the newest compatible build or "id@1.2.0" to
+        /// pin one.
+        /// <para>
+        /// The order is also precedence: where two plugins both claim a link, the one listed
+        /// first wins. Settling it here rather than by a number each plugin declares for itself
+        /// keeps the decision with the person who chose the plugins - and avoids every author
+        /// deciding theirs is the important one.
+        /// </para>
+        /// </summary>
+        public List<string> Install { get; set; } = [];
+
+        /// <summary>
+        /// Where plugins are kept. Relative paths are from the content root.
+        /// </summary>
+        public string Path { get; set; } = "plugins";
+
+        /// <summary>
+        /// Settings for individual plugins, keyed by plugin id. Reaches the plugin as its
+        /// <c>IProviderContext.Settings</c>.
+        /// </summary>
+        public Dictionary<string, Dictionary<string, string?>> Settings { get; set; } = [];
+    }
+
+    /// <summary>One plugin as a repository index describes it.</summary>
+    public sealed record PluginIndexEntry
+    {
+        public string Id { get; init; } = string.Empty;
+        public string? Name { get; init; }
+        public string Version { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Contract this was built against. The host implements exactly one and skips anything
+        /// else, because a contract that changed shape is not something to guess at.
+        /// </summary>
+        public int Abi { get; init; }
+
+        /// <summary>Path to the archive, relative to the index that named it.</summary>
+        public string File { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Hash of that archive. Checked after downloading, which is what makes a plugin
+        /// repository something you can host anywhere without also having to trust the host.
+        /// </summary>
+        public string Sha256 { get; init; } = string.Empty;
+    }
+}

--- a/src/ArgonFetch.Application/Plugins/ProviderContext.cs
+++ b/src/ArgonFetch.Application/Plugins/ProviderContext.cs
@@ -1,0 +1,91 @@
+using ArgonFetch.Abstractions;
+using ArgonFetch.Application.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace ArgonFetch.Application.Plugins
+{
+    /// <summary>Makes a context for one plugin to work with.</summary>
+    public interface IProviderContextFactory
+    {
+        IProviderContext For(string pluginId, Func<Uri, CancellationToken, Task<ProbeResult?>> probe);
+    }
+
+    public class ProviderContextFactory : IProviderContextFactory
+    {
+        private readonly IMediaHttpClients _httpClients;
+        private readonly IProxyPool _proxyPool;
+        private readonly IMemoryCache _cache;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly PluginOptions _options;
+
+        public ProviderContextFactory(
+            IMediaHttpClients httpClients,
+            IProxyPool proxyPool,
+            IMemoryCache cache,
+            ILoggerFactory loggerFactory,
+            PluginOptions options)
+        {
+            _httpClients = httpClients;
+            _proxyPool = proxyPool;
+            _cache = cache;
+            _loggerFactory = loggerFactory;
+            _options = options;
+        }
+
+        public IProviderContext For(string pluginId, Func<Uri, CancellationToken, Task<ProbeResult?>> probe) =>
+            new ProviderContext(
+                pluginId,
+                _httpClients,
+                _proxyPool,
+                _cache,
+                _loggerFactory.CreateLogger($"Plugin.{pluginId}"),
+                _options.Settings.TryGetValue(pluginId, out var settings) ? settings : [],
+                probe);
+
+        private sealed class ProviderContext : IProviderContext
+        {
+            private readonly string _pluginId;
+            private readonly IMediaHttpClients _httpClients;
+            private readonly IProxyPool _proxyPool;
+            private readonly Func<Uri, CancellationToken, Task<ProbeResult?>> _probe;
+
+            public ProviderContext(
+                string pluginId,
+                IMediaHttpClients httpClients,
+                IProxyPool proxyPool,
+                IMemoryCache cache,
+                ILogger logger,
+                IReadOnlyDictionary<string, string?> settings,
+                Func<Uri, CancellationToken, Task<ProbeResult?>> probe)
+            {
+                _pluginId = pluginId;
+                _httpClients = httpClients;
+                _proxyPool = proxyPool;
+                _probe = probe;
+                Cache = cache;
+                Logger = logger;
+                Settings = settings;
+            }
+
+            public IMemoryCache Cache { get; }
+
+            public ILogger Logger { get; }
+
+            public IReadOnlyDictionary<string, string?> Settings { get; }
+
+            // Whichever client the pool's next proxy needs, or the plain one. The same service
+            // the rest of the application fetches media through, so a plugin is subject to the
+            // same rotation rather than quietly going direct.
+            public HttpClient CreateHttpClient(bool rotateProxy = true) =>
+                _httpClients.For(rotateProxy ? _proxyPool.Next() : null);
+
+            public Task<ProbeResult?> ProbeAsync(Uri url, CancellationToken cancellationToken) =>
+                _probe(url, cancellationToken);
+
+            // Prefixed so two plugins caching "track:1" cannot overwrite one another - the cache
+            // is the application's, not any one plugin's.
+            public string CacheKey(string key) => $"plugin:{_pluginId}:{key}";
+        }
+    }
+}

--- a/src/ArgonFetch.Application/Plugins/ProviderRegistry.cs
+++ b/src/ArgonFetch.Application/Plugins/ProviderRegistry.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using ArgonFetch.Abstractions;
 using Microsoft.Extensions.Logging;
 
@@ -20,7 +21,18 @@ namespace ArgonFetch.Application.Plugins
 
     public class ProviderRegistry : IProviderRegistry
     {
-        private readonly IReadOnlyList<(string PluginId, ISourceProvider Provider)> _providers;
+        /// <summary>
+        /// How long one pattern may spend deciding.
+        /// <para>
+        /// A pattern is written by whoever wrote the plugin, and one that backtracks badly can
+        /// take a very long time over a URL built to provoke it. Every request is matched against
+        /// every installed pattern, so without a limit here one careless plugin would be enough
+        /// to stall the whole application.
+        /// </para>
+        /// </summary>
+        private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(100);
+
+        private readonly IReadOnlyList<Claim> _providers;
         private readonly ILogger<ProviderRegistry> _logger;
 
         public ProviderRegistry(IReadOnlyList<LoadedPlugin> plugins, ILogger<ProviderRegistry> logger)
@@ -32,7 +44,8 @@ namespace ArgonFetch.Application.Plugins
             // the plugins rather than to a number each plugin declares about itself - given the
             // chance, every author decides theirs is the important one.
             _providers = plugins
-                .SelectMany(plugin => plugin.Providers.Select(provider => (plugin.Id, provider)))
+                .SelectMany(plugin => plugin.Providers.Select(provider =>
+                    new Claim(plugin.Id, provider, Compile(plugin.Id, provider, logger))))
                 .ToList();
 
             Hooks = plugins.SelectMany(plugin => plugin.Hooks).ToList();
@@ -42,12 +55,55 @@ namespace ArgonFetch.Application.Plugins
 
         public IReadOnlyList<LoadedPlugin> Plugins { get; }
 
+        /// <summary>
+        /// Compiles a provider's declared patterns once, here, rather than on every request.
+        /// </summary>
+        private static IReadOnlyList<Regex> Compile(string pluginId, ISourceProvider provider, ILogger logger)
+        {
+            var compiled = new List<Regex>();
+
+            IReadOnlyList<string> patterns;
+
+            try
+            {
+                patterns = provider.UrlPatterns ?? [];
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "The {Id} plugin threw while listing the links it wants", pluginId);
+                return compiled;
+            }
+
+            foreach (var pattern in patterns)
+            {
+                try
+                {
+                    compiled.Add(new Regex(
+                        pattern,
+                        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant,
+                        MatchTimeout));
+                }
+                catch (ArgumentException ex)
+                {
+                    // One unusable pattern costs that pattern. The plugin may well have others,
+                    // and taking it out entirely over a typo helps nobody.
+                    logger.LogWarning(ex, "The {Id} plugin declared a pattern that does not compile: {Pattern}", pluginId, pattern);
+                }
+            }
+
+            if (compiled.Count == 0)
+                logger.LogWarning("The {Id} plugin declares no usable link patterns, so it will never be asked", pluginId);
+
+            return compiled;
+        }
+
         public ISourceProvider? For(Uri url)
         {
             // Every provider is asked, rather than stopping at the first that says yes. A second
             // claim on the same link is worth knowing about: left unsaid, the losing plugin
             // simply never runs and nobody can see why.
-            var claimed = _providers.Where(entry => Claims(entry, url)).ToList();
+            var address = url.ToString();
+            var claimed = _providers.Where(entry => Claims(entry, url, address)).ToList();
 
             if (claimed.Count == 0)
                 return null;
@@ -63,11 +119,18 @@ namespace ArgonFetch.Application.Plugins
             return claimed[0].Provider;
         }
 
-        private bool Claims((string PluginId, ISourceProvider Provider) entry, Uri url)
+        private bool Claims(Claim entry, Uri url, string address)
         {
             try
             {
-                return entry.Provider.CanHandle(url);
+                // The declared patterns first, then the provider's own say - which almost every
+                // provider leaves at the default, because the patterns were the whole answer.
+                return entry.Patterns.Any(pattern => pattern.IsMatch(address)) && entry.Provider.CanHandle(url);
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                LogPatternTimeout(entry.PluginId, address);
+                return false;
             }
             catch (Exception ex)
             {
@@ -78,5 +141,10 @@ namespace ArgonFetch.Application.Plugins
                 return false;
             }
         }
+
+        private void LogPatternTimeout(string pluginId, string address) =>
+            _logger.LogWarning("A link pattern from the {Id} plugin took too long over {Url} and was abandoned", pluginId, address);
+
+        private sealed record Claim(string PluginId, ISourceProvider Provider, IReadOnlyList<Regex> Patterns);
     }
 }

--- a/src/ArgonFetch.Application/Plugins/ProviderRegistry.cs
+++ b/src/ArgonFetch.Application/Plugins/ProviderRegistry.cs
@@ -1,0 +1,82 @@
+using ArgonFetch.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace ArgonFetch.Application.Plugins
+{
+    /// <summary>
+    /// Decides which provider, if any, wants a link.
+    /// </summary>
+    public interface IProviderRegistry
+    {
+        /// <summary>The provider that handles this link, or null to fetch it the ordinary way.</summary>
+        ISourceProvider? For(Uri url);
+
+        /// <summary>Every hook, to be applied in turn before a fetch.</summary>
+        IReadOnlyList<IFetchOptionsHook> Hooks { get; }
+
+        /// <summary>What is loaded, for the application information endpoint.</summary>
+        IReadOnlyList<LoadedPlugin> Plugins { get; }
+    }
+
+    public class ProviderRegistry : IProviderRegistry
+    {
+        private readonly IReadOnlyList<(string PluginId, ISourceProvider Provider)> _providers;
+        private readonly ILogger<ProviderRegistry> _logger;
+
+        public ProviderRegistry(IReadOnlyList<LoadedPlugin> plugins, ILogger<ProviderRegistry> logger)
+        {
+            Plugins = plugins;
+            _logger = logger;
+
+            // Configured order, which the loader preserved. Precedence belongs to whoever chose
+            // the plugins rather than to a number each plugin declares about itself - given the
+            // chance, every author decides theirs is the important one.
+            _providers = plugins
+                .SelectMany(plugin => plugin.Providers.Select(provider => (plugin.Id, provider)))
+                .ToList();
+
+            Hooks = plugins.SelectMany(plugin => plugin.Hooks).ToList();
+        }
+
+        public IReadOnlyList<IFetchOptionsHook> Hooks { get; }
+
+        public IReadOnlyList<LoadedPlugin> Plugins { get; }
+
+        public ISourceProvider? For(Uri url)
+        {
+            // Every provider is asked, rather than stopping at the first that says yes. A second
+            // claim on the same link is worth knowing about: left unsaid, the losing plugin
+            // simply never runs and nobody can see why.
+            var claimed = _providers.Where(entry => Claims(entry, url)).ToList();
+
+            if (claimed.Count == 0)
+                return null;
+
+            if (claimed.Count > 1)
+            {
+                _logger.LogWarning(
+                    "{Winner} handles {Url}; also claimed by {Others}",
+                    claimed[0].PluginId, url,
+                    string.Join(", ", claimed.Skip(1).Select(entry => entry.PluginId)));
+            }
+
+            return claimed[0].Provider;
+        }
+
+        private bool Claims((string PluginId, ISourceProvider Provider) entry, Uri url)
+        {
+            try
+            {
+                return entry.Provider.CanHandle(url);
+            }
+            catch (Exception ex)
+            {
+                // A provider that throws while deciding has answered no. It is asked on every
+                // request, including ones for sources it has nothing to do with, so a fault
+                // here must not be able to break an unrelated download.
+                _logger.LogWarning(ex, "The {Id} plugin threw while deciding about {Url}", entry.PluginId, url);
+                return false;
+            }
+        }
+    }
+}

--- a/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
@@ -1,6 +1,8 @@
 ﻿using ArgonFetch.Application.Dtos;
 using ArgonFetch.Application.Enums;
 using ArgonFetch.Application.Services;
+using ArgonFetch.Abstractions;
+using ArgonFetch.Application.Plugins;
 using ArgonFetch.Application.Services.DDLFetcherServices;
 using MediatR;
 using Microsoft.AspNetCore.Http;
@@ -11,6 +13,7 @@ using YoutubeDLSharp.Metadata;
 using YoutubeDLSharp.Options;
 using YouTubeMusicAPI.Client;
 using YouTubeMusicAPI.Models.Search;
+using MediaTags = ArgonFetch.Application.Services.MediaTags;
 
 namespace ArgonFetch.Application.Queries
 {
@@ -37,6 +40,8 @@ namespace ArgonFetch.Application.Queries
         private readonly IProxyUrlBuilder _proxyUrlBuilder;
         private readonly IProxyPool _proxyPool;
         private readonly IToolPaths _toolPaths;
+        private readonly IProviderRegistry _providers;
+        private readonly IProviderContextFactory _providerContexts;
         private readonly ILogger<GetMediaQueryHandler> _logger;
 
         // Enough to hold the album version when search leads with a radio edit and a remaster,
@@ -56,6 +61,13 @@ namespace ArgonFetch.Application.Queries
         // requested them, so it has to travel with them to the stream endpoint.
         private string? _fetchProxy;
 
+        // Set when a plugin rewrote the link. Knowing the release better than the page it was
+        // redirected to is the reason the track was matched rather than merely searched for, so
+        // what the plugin said wins over what the fetch reports.
+        private MediaTags? _overrideTags;
+        private string? _overrideCover;
+        private string? _originalUrl;
+
         public GetMediaQueryHandler(
             ISpotifyMetadataService spotifyMetadataService,
             YouTubeMusicClient ytmClient,
@@ -68,6 +80,8 @@ namespace ArgonFetch.Application.Queries
             IProxyUrlBuilder proxyUrlBuilder,
             IProxyPool proxyPool,
             IToolPaths toolPaths,
+            IProviderRegistry providers,
+            IProviderContextFactory providerContexts,
             ILogger<GetMediaQueryHandler> logger
             )
         {
@@ -82,6 +96,8 @@ namespace ArgonFetch.Application.Queries
             _proxyUrlBuilder = proxyUrlBuilder;
             _proxyPool = proxyPool;
             _toolPaths = toolPaths;
+            _providers = providers;
+            _providerContexts = providerContexts;
             _logger = logger;
         }
 
@@ -98,6 +114,15 @@ namespace ArgonFetch.Application.Queries
 
         private async Task<ResourceInformationDto> Resolve(GetMediaQuery request, CancellationToken cancellationToken)
         {
+            // Plugins first, and only for a real link - a search term is nobody's source.
+            if (Uri.TryCreate(request.Query, UriKind.Absolute, out var link))
+            {
+                var handled = await AskProvidersAsync(link, request, cancellationToken);
+
+                if (handled is not null)
+                    return handled;
+            }
+
             var platform = PlatformIdentifierService.IdentifyPlatform(request.Query);
 
             if (platform == Platform.Spotify)
@@ -147,7 +172,7 @@ namespace ArgonFetch.Application.Queries
 
                 // Carried into the cache so the stream endpoint can name and tag the file it
                 // serves; by then only a key is left to identify the media by.
-                var tags = new MediaTags(resultData.Title, resultData.Uploader);
+                var tags = _overrideTags ?? new MediaTags(resultData.Title, resultData.Uploader);
 
                 var audioRenditions = _proxyUrlBuilder.BuildRenditions(
                     RenditionPicker.PickAudio(AudioSources(resultData.Formats)),
@@ -203,18 +228,186 @@ namespace ArgonFetch.Application.Queries
                     [
                             new MediaInformationDto
                             {
-                                RequestedUrl = request.Query,
+                                RequestedUrl = _originalUrl ?? request.Query,
                                 Video = combinedReferences,  // Either pre-muxed or FFmpeg-combined
                                 Audio = audioReferences,      // Audio-only option
-                                CoverUrl = thumbnailUrl,
-                                Title = resultData.Title,
-                                Author = resultData.Uploader
+                                CoverUrl = _overrideCover ?? thumbnailUrl,
+                                Title = tags.Title ?? string.Empty,
+                                Author = tags.Artist ?? string.Empty
                             }
                     ]
                 };
             }
             else
                 throw new NotSupportedException("This isn't implemented yet");
+        }
+
+        /// <summary>
+        /// Offers the link to whichever plugin claims it, and turns its answer into a result.
+        /// <para>
+        /// Null when no plugin wanted it, or when the one that did decided there was nothing to
+        /// do - both of which mean carrying on and fetching the link the ordinary way.
+        /// </para>
+        /// </summary>
+        private async Task<ResourceInformationDto?> AskProvidersAsync(
+            Uri link,
+            GetMediaQuery request,
+            CancellationToken cancellationToken)
+        {
+            var provider = _providers.For(link);
+
+            if (provider is null)
+                return null;
+
+            ProviderOutcome outcome;
+
+            try
+            {
+                var context = _providerContexts.For(provider.Id, ProbeAsync);
+
+                outcome = await provider.PrepareAsync(link, context, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // A plugin that fails is not a reason to refuse the link outright: yt-dlp knows
+                // a great many sources, and the ordinary path may well handle it.
+                _logger.LogWarning(ex, "The {Id} plugin failed on {Url}; falling back", provider.Id, link);
+                return null;
+            }
+
+            switch (outcome)
+            {
+                case ProviderOutcome.RewriteOutcome rewrite:
+                    // The fetch that follows is the ordinary one; it is only pointed elsewhere,
+                    // and told what to call what it finds.
+                    _logger.LogInformation("The {Id} plugin redirected {From} to {To}", provider.Id, link, rewrite.Url);
+
+                    _overrideTags = new MediaTags(rewrite.Tags.Title, rewrite.Tags.Artist);
+                    _overrideCover = rewrite.CoverUrl;
+                    _originalUrl = request.Query;
+                    request.Query = rewrite.Url.ToString();
+
+                    return null;
+
+                case ProviderOutcome.ListingOutcome listing:
+                    return MapCollection(listing.Collection, provider.Id);
+
+                case ProviderOutcome.CompleteOutcome complete:
+                    return MapMedia(complete.Media, request.Query);
+
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// A plugin's listing, as the API describes one. Entries stay unresolved, exactly as they
+        /// do for a collection yt-dlp listed.
+        /// </summary>
+        private ResourceInformationDto MapCollection(CollectionResult collection, string pluginId)
+        {
+            if (collection.MayBeTruncated)
+            {
+                _logger.LogInformation(
+                    "The {Id} plugin returned {Count} entries and says there may be more it could not send",
+                    pluginId, collection.Items.Count);
+            }
+
+            return new ResourceInformationDto
+            {
+                Type = MediaType.PlayList,
+                Title = collection.Title,
+                Author = collection.Author,
+                CoverUrl = collection.CoverUrl,
+                MediaItems = collection.Items
+                    .Select(item => new MediaInformationDto
+                    {
+                        RequestedUrl = item.Url.ToString(),
+                        Title = item.Title,
+                        Author = item.Author ?? string.Empty,
+                        CoverUrl = item.CoverUrl ?? collection.CoverUrl,
+                        Audio = null,
+                        Video = null
+                    })
+                    .ToList()
+            };
+        }
+
+        /// <summary>
+        /// Media a plugin fetched itself. It hands over plain addresses; caching them, hiding
+        /// them behind keys and building the URLs a client is given stay here, because that is
+        /// how this application serves bytes and it is not a plugin's business.
+        /// </summary>
+        private ResourceInformationDto MapMedia(MediaResult media, string requestedUrl)
+        {
+            var tags = new MediaTags(media.Title, media.Author);
+
+            var audio = BuildReference(media.Streams.Where(stream => stream.IsAudio), isAudio: true, tags);
+            var video = BuildReference(media.Streams.Where(stream => !stream.IsAudio), isAudio: false, tags);
+
+            return new ResourceInformationDto
+            {
+                Type = MediaType.Media,
+                MediaItems =
+                [
+                    new MediaInformationDto
+                    {
+                        RequestedUrl = requestedUrl,
+                        Video = video,
+                        Audio = audio,
+                        CoverUrl = media.CoverUrl,
+                        Title = media.Title,
+                        Author = media.Author ?? string.Empty
+                    }
+                ]
+            };
+        }
+
+        private StreamReferenceDto? BuildReference(IEnumerable<MediaStream> streams, bool isAudio, MediaTags tags)
+        {
+            var renditions = streams
+                .Select(stream => new MediaRenditionDto
+                {
+                    Key = _cacheService.CacheSingleUrl(
+                        stream.Url.ToString(),
+                        isAudio,
+                        stream.MimeType,
+                        stream.Proxy,
+                        tags),
+                    Label = stream.Label ?? (isAudio ? "Audio" : "Video"),
+                    FileExtension = stream.FileExtension
+                        ?? MediaFormats.ExtensionFor(stream.MimeType)
+                        ?? (isAudio ? ".m4a" : ".mp4"),
+                    MimeType = stream.MimeType ?? string.Empty,
+                    FileSizeBytes = stream.SizeBytes,
+                    UrlType = UrlType.Media
+                })
+                .ToList();
+
+            return renditions.Count == 0
+                ? null
+                : new StreamReferenceDto { UrlType = UrlType.Media, Renditions = renditions };
+        }
+
+        /// <summary>
+        /// What the fetch engine can say about a link without downloading it, for a plugin
+        /// choosing between candidates.
+        /// </summary>
+        private async Task<ProbeResult?> ProbeAsync(Uri url, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var fetched = await YT_DLP_Fetch(url.ToString());
+
+                return new ProbeResult(fetched.Title, fetched.Uploader, fetched.Duration);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // A link that cannot be read is an answer, not a fault - it is exactly what a
+                // plugin sifting candidates wants to know.
+                _logger.LogDebug(ex, "Could not probe {Url}", url);
+                return null;
+            }
         }
 
         /// <summary>

--- a/src/ArgonFetch.Tests/ArgonFetch.Tests.csproj
+++ b/src/ArgonFetch.Tests/ArgonFetch.Tests.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ArgonFetch.Abstractions\ArgonFetch.Abstractions.csproj" />
     <ProjectReference Include="..\ArgonFetch.Application\ArgonFetch.Application.csproj" />
   </ItemGroup>
 

--- a/src/ArgonFetch.Tests/ProviderRegistryTests.cs
+++ b/src/ArgonFetch.Tests/ProviderRegistryTests.cs
@@ -10,8 +10,8 @@ namespace ArgonFetch.Tests
         public void For_PicksTheProviderThatClaimsTheLink()
         {
             var registry = Registry(
-                Plugin("spotify", new StubProvider("spotify", "open.spotify.com")),
-                Plugin("tiktok", new StubProvider("tiktok", "tiktok.com")));
+                Plugin("spotify", new StubProvider("spotify", @"^https?://([\w-]+\.)*spotify\.com/")),
+                Plugin("tiktok", new StubProvider("tiktok", @"^https?://([\w-]+\.)*tiktok\.com/")));
 
             Assert.Equal("tiktok", registry.For(new Uri("https://www.tiktok.com/@a/video/1"))?.Id);
         }
@@ -19,7 +19,7 @@ namespace ArgonFetch.Tests
         [Fact]
         public void For_LeavesALinkNobodyClaimsToTheOrdinaryPath()
         {
-            var registry = Registry(Plugin("spotify", new StubProvider("spotify", "open.spotify.com")));
+            var registry = Registry(Plugin("spotify", new StubProvider("spotify", @"^https?://([\w-]+\.)*spotify\.com/")));
 
             Assert.Null(registry.For(new Uri("https://www.youtube.com/watch?v=dQw4w9WgXcQ")));
         }
@@ -30,8 +30,8 @@ namespace ArgonFetch.Tests
             // Two plugins wanting the same link is a decision for whoever chose them, not for
             // whichever one happened to load first.
             var registry = Registry(
-                Plugin("spotify-fork", new StubProvider("spotify-fork", "open.spotify.com")),
-                Plugin("spotify", new StubProvider("spotify", "open.spotify.com")));
+                Plugin("spotify-fork", new StubProvider("spotify-fork", @"^https?://([\w-]+\.)*spotify\.com/")),
+                Plugin("spotify", new StubProvider("spotify", @"^https?://([\w-]+\.)*spotify\.com/")));
 
             Assert.Equal("spotify-fork", registry.For(new Uri("https://open.spotify.com/track/1"))?.Id);
         }
@@ -43,9 +43,31 @@ namespace ArgonFetch.Tests
             // nothing to do with, so one that throws must not break an unrelated download.
             var registry = Registry(
                 Plugin("broken", new ThrowingProvider()),
-                Plugin("spotify", new StubProvider("spotify", "open.spotify.com")));
+                Plugin("spotify", new StubProvider("spotify", @"^https?://([\w-]+\.)*spotify\.com/")));
 
             Assert.Equal("spotify", registry.For(new Uri("https://open.spotify.com/track/1"))?.Id);
+        }
+
+        [Fact]
+        public void For_IgnoresAPatternThatDoesNotCompile()
+        {
+            // A typo in one pattern costs that pattern. Taking the plugin out entirely over it
+            // would help nobody, and the working patterns beside it are still worth having.
+            var registry = Registry(Plugin("broken-pattern", new BadPatternProvider(
+                "broken-pattern", "([unclosed", @"^https?://([\w-]+\.)*spotify\.com/")));
+
+            Assert.Equal("broken-pattern", registry.For(new Uri("https://open.spotify.com/track/1"))?.Id);
+        }
+
+        [Fact]
+        public void For_AsksTheProviderOnlyAfterAPatternMatched()
+        {
+            // The throwing provider claims every link, so if it were consulted for this one the
+            // exception would be swallowed and it would be the winner that never ran.
+            var registry = Registry(
+                Plugin("spotify", new StubProvider("spotify", @"^https?://([\w-]+\.)*spotify\.com/")));
+
+            Assert.Null(registry.For(new Uri("https://example.com/whatever")));
         }
 
         [Fact]
@@ -64,11 +86,11 @@ namespace ArgonFetch.Tests
         private static LoadedPlugin Plugin(string id, ISourceProvider provider) =>
             new(id, null, "1.0", [provider], []);
 
-        private sealed class StubProvider(string id, string host) : ISourceProvider
+        private sealed class StubProvider(string id, params string[] patterns) : ISourceProvider
         {
             public string Id { get; } = id;
 
-            public bool CanHandle(Uri url) => url.Host.Contains(host, StringComparison.OrdinalIgnoreCase);
+            public IReadOnlyList<string> UrlPatterns { get; } = patterns;
 
             public Task<ProviderOutcome> PrepareAsync(Uri url, IProviderContext context, CancellationToken cancellationToken) =>
                 Task.FromResult(ProviderOutcome.PassThrough);
@@ -78,10 +100,22 @@ namespace ArgonFetch.Tests
         {
             public string Id => "broken";
 
+            public IReadOnlyList<string> UrlPatterns => [".*"];
+
             public bool CanHandle(Uri url) => throw new InvalidOperationException("bad plugin");
 
             public Task<ProviderOutcome> PrepareAsync(Uri url, IProviderContext context, CancellationToken cancellationToken) =>
                 throw new NotSupportedException();
+        }
+
+        private sealed class BadPatternProvider(string id, params string[] patterns) : ISourceProvider
+        {
+            public string Id { get; } = id;
+
+            public IReadOnlyList<string> UrlPatterns { get; } = patterns;
+
+            public Task<ProviderOutcome> PrepareAsync(Uri url, IProviderContext context, CancellationToken cancellationToken) =>
+                Task.FromResult(ProviderOutcome.PassThrough);
         }
 
         private sealed class StubHook : IFetchOptionsHook

--- a/src/ArgonFetch.Tests/ProviderRegistryTests.cs
+++ b/src/ArgonFetch.Tests/ProviderRegistryTests.cs
@@ -1,0 +1,117 @@
+using ArgonFetch.Abstractions;
+using ArgonFetch.Application.Plugins;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace ArgonFetch.Tests
+{
+    public class ProviderRegistryTests
+    {
+        [Fact]
+        public void For_PicksTheProviderThatClaimsTheLink()
+        {
+            var registry = Registry(
+                Plugin("spotify", new StubProvider("spotify", "open.spotify.com")),
+                Plugin("tiktok", new StubProvider("tiktok", "tiktok.com")));
+
+            Assert.Equal("tiktok", registry.For(new Uri("https://www.tiktok.com/@a/video/1"))?.Id);
+        }
+
+        [Fact]
+        public void For_LeavesALinkNobodyClaimsToTheOrdinaryPath()
+        {
+            var registry = Registry(Plugin("spotify", new StubProvider("spotify", "open.spotify.com")));
+
+            Assert.Null(registry.For(new Uri("https://www.youtube.com/watch?v=dQw4w9WgXcQ")));
+        }
+
+        [Fact]
+        public void For_SettlesAClashByTheOrderTheOperatorInstalledThem()
+        {
+            // Two plugins wanting the same link is a decision for whoever chose them, not for
+            // whichever one happened to load first.
+            var registry = Registry(
+                Plugin("spotify-fork", new StubProvider("spotify-fork", "open.spotify.com")),
+                Plugin("spotify", new StubProvider("spotify", "open.spotify.com")));
+
+            Assert.Equal("spotify-fork", registry.For(new Uri("https://open.spotify.com/track/1"))?.Id);
+        }
+
+        [Fact]
+        public void For_TreatsAProviderThatThrowsAsNotInterested()
+        {
+            // CanHandle is asked of every plugin on every request, including for sources it has
+            // nothing to do with, so one that throws must not break an unrelated download.
+            var registry = Registry(
+                Plugin("broken", new ThrowingProvider()),
+                Plugin("spotify", new StubProvider("spotify", "open.spotify.com")));
+
+            Assert.Equal("spotify", registry.For(new Uri("https://open.spotify.com/track/1"))?.Id);
+        }
+
+        [Fact]
+        public void Hooks_AreCollectedFromEveryPlugin()
+        {
+            var registry = Registry(
+                new LoadedPlugin("a", null, "1.0", [], [new StubHook()]),
+                new LoadedPlugin("b", null, "1.0", [], [new StubHook()]));
+
+            Assert.Equal(2, registry.Hooks.Count);
+        }
+
+        private static ProviderRegistry Registry(params LoadedPlugin[] plugins) =>
+            new(plugins, NullLogger<ProviderRegistry>.Instance);
+
+        private static LoadedPlugin Plugin(string id, ISourceProvider provider) =>
+            new(id, null, "1.0", [provider], []);
+
+        private sealed class StubProvider(string id, string host) : ISourceProvider
+        {
+            public string Id { get; } = id;
+
+            public bool CanHandle(Uri url) => url.Host.Contains(host, StringComparison.OrdinalIgnoreCase);
+
+            public Task<ProviderOutcome> PrepareAsync(Uri url, IProviderContext context, CancellationToken cancellationToken) =>
+                Task.FromResult(ProviderOutcome.PassThrough);
+        }
+
+        private sealed class ThrowingProvider : ISourceProvider
+        {
+            public string Id => "broken";
+
+            public bool CanHandle(Uri url) => throw new InvalidOperationException("bad plugin");
+
+            public Task<ProviderOutcome> PrepareAsync(Uri url, IProviderContext context, CancellationToken cancellationToken) =>
+                throw new NotSupportedException();
+        }
+
+        private sealed class StubHook : IFetchOptionsHook
+        {
+            public void Configure(IFetchOptions options, Uri url) { }
+        }
+    }
+
+    public class PluginInstallRequestTests
+    {
+        [Theory]
+        [InlineData("spotify", "spotify", null)]
+        [InlineData("spotify@1.2.0", "spotify", "1.2.0")]
+        [InlineData("  spotify @ 1.2.0  ", "spotify", "1.2.0")]
+        // A trailing separator with nothing after it asks for the newest, rather than for a
+        // version named the empty string.
+        [InlineData("spotify@", "spotify", null)]
+        public void Parse_ReadsAnIdAndAnOptionalPinnedVersion(string request, string id, string? version)
+        {
+            var parsed = PluginInstaller.Parse(request);
+
+            Assert.NotNull(parsed);
+            Assert.Equal(id, parsed!.Value.Id);
+            Assert.Equal(version, parsed.Value.Version);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Parse_IgnoresAnEmptyEntry(string request) =>
+            Assert.Null(PluginInstaller.Parse(request));
+    }
+}


### PR DESCRIPTION
Closes #93.

yt-dlp fetches things the ordinary way and most links need nothing more. A plugin exists for the ones that do, and there are exactly three of those plus "nothing to do":

| Outcome | For |
|---|---|
| `Rewrite` | A link that must become a different link first - Spotify serves no audio, so it describes a track and points the download at the same recording elsewhere, keeping its own title and credit |
| `Listing` | An album or playlist. Entries are listed, never resolved - resolving a thousand to show a list would take the better part of an hour |
| `Complete` | A source some other code fetches on its own, skipping yt-dlp entirely |
| `PassThrough` | Nothing to do |

Plus `IFetchOptionsHook`, separate because it composes: several hooks may apply to one fetch, where exactly one provider ever handles a link. That is where a cookies file or a format selector belongs.

## Which links a plugin wants

Declared, not coded:

```csharp
public IReadOnlyList<string> UrlPatterns =>
[
    @"^https?://([\w-]+\.)*spotify\.com/",
];
```

The host compiles them once instead of on every request, applies a 100 ms limit so a pattern that backtracks badly cannot stall a download, and can say plainly which plugin claimed what. The usual plugin writes one line and no matching code at all.

## Two plugins claiming one link

Settled by the order the operator listed them in, not by a number each plugin declares about itself - given the chance, every author decides theirs is the important one.

Every provider is asked rather than stopping at the first, so a second claim is **logged**. Left unsaid, the losing plugin simply never runs and nobody can see why.

## Isolation

Each plugin loads into its own `AssemblyLoadContext`, because two of them will eventually bring different versions of the same dependency and that should stay their problem. The contract is deliberately excluded and resolved from the host - types have identity per context, so a plugin loading its own copy implements an unrelated `ISourceProvider` and fails claiming `ISourceProvider` cannot be cast to `ISourceProvider`. That is why a plugin references the package with `ExcludeAssets="runtime"`, and why the template and the CI both check for it.

## Failure is contained

- A provider that throws while deciding has answered no.
- A provider that fails while preparing falls back to the ordinary fetch.
- A repository that cannot be reached leaves what is already installed alone rather than taking the application down.
- A pattern that does not compile costs that pattern, not the plugin.

## Configuration

```jsonc
"Plugins": {
  "Repositories": [ "https://raw.githubusercontent.com/ArgonFetch/ArgonFetchPlugins/repo/index.json" ],
  "Install": [ "spotify", "tiktok" ]
}
```

Desired state: what is listed is installed, what is not is removed. Installation happens once at startup and never during a request.

## Testing

- 93 unit tests here, 47 in the plugins repository (the matcher's tests moved with the matcher).
- Live, against the running application: Spotify track, Spotify album, plain YouTube video and a 183-entry YouTube playlist all resolve, with no fallbacks.
- Verified the published plugin does **not** contain `ArgonFetch.Abstractions.dll`.

## One bug worth recording

The loader worked, reported the plugin, answered which links it wanted - and then failed the first time the plugin reached one of its own dependencies, saying the load context was already unloaded. A collectible context is collected once nothing refers to it, and the providers built from it are instances, which do not root the context their type was loaded into. It fell back to the ordinary fetch, which for Spotify still worked, because the code this replaces was still there: the right answer arriving by the wrong route, invisibly.

## Not done here

`ArgonFetch.Abstractions` is not on nuget.org yet, so the plugins build against a local feed. The trusted-publishing workflow is in this PR and the nuget.org policy is configured; tagging `abstractions-v1.0.0` after this merges publishes it.
