### PR TITLE
Replace MediatR with Mediator

### DIFF
--- a/src/ArgonFetch.API/ArgonFetch.API.csproj
+++ b/src/ArgonFetch.API/ArgonFetch.API.csproj
@@ -13,7 +13,11 @@
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-    <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
+    <PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
 	<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.10" />
 	<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.1.2" />

--- a/src/ArgonFetch.API/Controllers/FetchController.cs
+++ b/src/ArgonFetch.API/Controllers/FetchController.cs
@@ -1,7 +1,7 @@
 ﻿using ArgonFetch.Application.Dtos;
 using ArgonFetch.Application.Queries;
 using ArgonFetch.Application.Services;
-using MediatR;
+using Mediator;
 using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel.DataAnnotations;
 

--- a/src/ArgonFetch.API/Controllers/StreamController.cs
+++ b/src/ArgonFetch.API/Controllers/StreamController.cs
@@ -1,7 +1,7 @@
 ﻿using ArgonFetch.Application.Queries;
 using ArgonFetch.Application.Services;
 using System.Text.Json;
-using MediatR;
+using Mediator;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel.DataAnnotations;

--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -3,7 +3,7 @@ using ArgonFetch.Application.Queries;
 using ArgonFetch.Application.Validators;
 using FluentValidation;
 using FluentValidation.AspNetCore;
-using MediatR;
+using Mediator;
 using System.Text.Json.Serialization;
 using YoutubeDLSharp;
 
@@ -35,8 +35,10 @@ builder.Services.AddControllers()
         o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 builder.Services.AddSpaStaticFiles(spaStaticFilesOptions => { spaStaticFilesOptions.RootPath = "wwwroot/browser"; });
 
-// Add MediatR
-builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(GetMediaQuery).Assembly));
+// Handlers are wired up at compile time by the source generator rather than found by
+// reflection at startup, so a handler that does not exist is a build error rather than a
+// request that fails once somebody makes it.
+builder.Services.AddMediator(options => options.ServiceLifetime = ServiceLifetime.Scoped);
 
 // Register In memory caching
 builder.Services.AddMemoryCache();

--- a/src/ArgonFetch.Abstractions/ArgonFetch.Abstractions.csproj
+++ b/src/ArgonFetch.Abstractions/ArgonFetch.Abstractions.csproj
@@ -45,8 +45,8 @@
       them: a plugin that needs a logger should not be handed a second logging abstraction to
       learn. Nothing else may be added without the same argument.
     -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.11" />
   </ItemGroup>
 
 </Project>

--- a/src/ArgonFetch.Application/ArgonFetch.Application.csproj
+++ b/src/ArgonFetch.Application/ArgonFetch.Application.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageReference Include="YoutubeDLSharp" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/ArgonFetch.Application/Behaviors/ValidationBehavior.cs
+++ b/src/ArgonFetch.Application/Behaviors/ValidationBehavior.cs
@@ -1,5 +1,5 @@
 ﻿using FluentValidation;
-using MediatR;
+using Mediator;
 
 namespace ArgonFetch.Application.Behaviors
 {
@@ -13,7 +13,7 @@ namespace ArgonFetch.Application.Behaviors
             _validators = validators;
         }
 
-        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        public async ValueTask<TResponse> Handle(TRequest request, MessageHandlerDelegate<TRequest, TResponse> next, CancellationToken cancellationToken)
         {
             if (_validators.Any())
             {
@@ -31,7 +31,7 @@ namespace ArgonFetch.Application.Behaviors
                     throw new ValidationException(failures);
             }
 
-            return await next();
+            return await next(request, cancellationToken);
         }
     }
 }

--- a/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
@@ -6,7 +6,7 @@ using ArgonFetch.Application.Services;
 using MediaTags = ArgonFetch.Application.Services.MediaTags;
 using ArgonFetch.Abstractions;
 using ArgonFetch.Application.Plugins;
-using MediatR;
+using Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -78,7 +78,7 @@ namespace ArgonFetch.Application.Queries
             _logger = logger;
         }
 
-        public async Task<ResourceInformationDto> Handle(GetMediaQuery request, CancellationToken cancellationToken)
+        public async ValueTask<ResourceInformationDto> Handle(GetMediaQuery request, CancellationToken cancellationToken)
         {
             var resolved = await Resolve(request, cancellationToken);
 

--- a/src/ArgonFetch.Application/Queries/StreamArchiveQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamArchiveQuery.cs
@@ -4,7 +4,7 @@ using ArgonFetch.Application.Dtos;
 using ArgonFetch.Application.Enums;
 using ArgonFetch.Application.Interfaces;
 using ArgonFetch.Application.Services;
-using MediatR;
+using Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
@@ -82,7 +82,7 @@ namespace ArgonFetch.Application.Queries
             _logger = logger;
         }
 
-        public async Task<StreamResult> Handle(StreamArchiveQuery request, CancellationToken cancellationToken)
+        public async ValueTask<StreamResult> Handle(StreamArchiveQuery request, CancellationToken cancellationToken)
         {
             ResourceInformationDto listing;
 

--- a/src/ArgonFetch.Application/Queries/StreamCombinedMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamCombinedMediaQuery.cs
@@ -1,6 +1,6 @@
 ﻿using ArgonFetch.Application.Interfaces;
 using ArgonFetch.Application.Services;
-using MediatR;
+using Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
@@ -36,7 +36,7 @@ namespace ArgonFetch.Application.Queries
             _logger = logger;
         }
 
-        public async Task<StreamResult> Handle(StreamCombinedMediaQuery request, CancellationToken cancellationToken)
+        public async ValueTask<StreamResult> Handle(StreamCombinedMediaQuery request, CancellationToken cancellationToken)
         {
             try
             {

--- a/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
@@ -1,6 +1,6 @@
 ﻿using ArgonFetch.Application.Interfaces;
 using ArgonFetch.Application.Services;
-using MediatR;
+using Mediator;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using System.Net.Http;
@@ -59,7 +59,7 @@ namespace ArgonFetch.Application.Queries
             _logger = logger;
         }
 
-        public async Task<StreamResult> Handle(StreamMediaQuery request, CancellationToken cancellationToken)
+        public async ValueTask<StreamResult> Handle(StreamMediaQuery request, CancellationToken cancellationToken)
         {
             try
             {

--- a/src/ArgonFetch.Infrastructure/ArgonFetch.Infrastructure.csproj
+++ b/src/ArgonFetch.Infrastructure/ArgonFetch.Infrastructure.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
   </ItemGroup>
 
 </Project>

--- a/src/ArgonFetch.Tests/ArgonFetch.Tests.csproj
+++ b/src/ArgonFetch.Tests/ArgonFetch.Tests.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
MediatR is Apache-2.0 up to 12.x and **commercially licensed from 13 onwards**. We were pinned at 12.4.1, so staying current meant either accepting those terms or pinning an old version forever - and pinning to avoid a licence is not a decision that improves with age.

[Mediator](https://github.com/martinothamar/Mediator) is MIT, and resolves handlers with a **source generator** rather than scanning assemblies at startup: a request with no handler is now a build error instead of a request that fails the first time somebody makes one.

Verified with the package metadata rather than from memory:

| | Licence |
|---|---|
| MediatR 12.4.1 | `Apache-2.0` |
| MediatR 14.2.0 | custom `LICENSE.md` |
| Mediator 3.0.2 | MIT |

Three API differences:

- Handlers return `ValueTask` rather than `Task` - the allocation the library exists to avoid.
- A pipeline behaviour is handed the message and token rather than closing over them, so the delegate is `MessageHandlerDelegate<TMessage, TResponse>` and `next()` takes arguments.
- `AddMediator(options => ...)` with a lifetime, not an assembly scan.

## Testing

93 unit tests pass. Live against the running application: validation still refuses a request with no `url` (400), and a Spotify track, a Spotify album and a plain YouTube link all resolve; streaming returns 206.