### PR TITLE
Trim the comments back to the ones that earn their place

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Paste a link, get the media. ArgonFetch resolves the URL, picks the best availab
 streams and serves them back as a normal file download.
 
 - **No API keys.** Nothing to register, no credentials to configure — including Spotify.
+- **Plugins.** Sources yt-dlp cannot reach are installed by name rather than built in, and anyone can publish one.
 - **Audio or video**, at a quality you choose.
 - **Web interface and REST API**, with Swagger docs.
 - **One container, no database.** Runs anywhere Docker does.
@@ -37,8 +38,8 @@ streams and serves them back as a normal file download.
 | Platform | Status | Notes |
 |---|---|---|
 | YouTube | ✅ Video and audio | Muxes separate video/audio streams when no pre-muxed format exists |
-| Spotify | ✅ Tracks, playlists and albums | Metadata is read from the public pages; audio comes from the matching YouTube Music result |
-| TikTok | ✅ | |
+| Spotify | ✅ Tracks, playlists and albums | Needs the `spotify` plugin. Metadata is read from the public pages; audio comes from the matching YouTube Music result |
+| TikTok | ✅ | Needs the `tiktok` plugin |
 | SoundCloud | ✅ | Except the licensed catalogue, which is DRM protected and refused |
 | Instagram | ⚠️ Needs `COOKIES_PATH` | Instagram serves media only to a signed-in session; supply one and it works |
 | Playlists | ✅ Any source | Resolved as a collection; download them individually or the whole list as one zip |

--- a/compose.yml
+++ b/compose.yml
@@ -11,6 +11,9 @@ services:
       # yt-dlp and FFmpeg are fetched on boot rather than baked into the image. Keeping them
       # here means a restart reuses them instead of downloading roughly 100MB again.
       - tools:/tools
+      # Plugins are downloaded at boot too, for the same reason: without this they are fetched
+      # again on every start.
+      - plugins:/plugins
       # Uncomment for sources that need a signed-in session, e.g. Instagram, and set
       # COOKIES_PATH=/config/cookies.txt in .env. Treat the file as a credential.
       # - ./cookies.txt:/config/cookies.txt:ro
@@ -18,3 +21,4 @@ services:
 
 volumes:
   tools:
+  plugins:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,13 +11,55 @@ Everything is set through environment variables, normally in the `.env` file nex
 | `ASPNETCORE_ENVIRONMENT` | no | `Production` by default. `Development` also enables the Swagger UI |
 | `TOOLS_PATH` | no | Where `yt-dlp` and `FFmpeg` are downloaded to. `/tools` in the image, which is the path the compose file mounts a volume on. Must be writable by the runtime user |
 | `PROXY_LIST_PATH` | no | File with one proxy per line, rotated across `yt-dlp` fetches so they do not all leave from the same IP. See [below](#proxy-rotation) |
+| `COOKIES_PATH` | no | Netscape-format cookies file exported from a signed-in browser, for sources that serve nothing to strangers. See [Platforms](/platforms#sites-that-need-an-account) |
+| `Plugins__*` | for Spotify and TikTok | Which plugins to install and where from. See [below](#plugins) |
 
 A complete `.env` for a public deployment:
 
 ```ini
 ASPNETCORE_ENVIRONMENT=Production
 CORS_ALLOWED_ORIGINS=https://argonfetch.example.com
+
+Plugins__Repositories__0=https://raw.githubusercontent.com/ArgonFetch/ArgonFetchPlugins/repo/index.json
+Plugins__Install__0=spotify
+Plugins__Install__1=tiktok
 ```
+
+## Plugins
+
+`yt-dlp` fetches most links on its own. A few sources need something else first - Spotify
+serves no audio anyone can download, TikTok watermarks what it serves - and those are
+**plugins**, installed by name rather than built in.
+
+```ini
+Plugins__Repositories__0=https://raw.githubusercontent.com/ArgonFetch/ArgonFetchPlugins/repo/index.json
+Plugins__Install__0=spotify
+Plugins__Install__1=tiktok
+```
+
+Or, if you configure with a file rather than the environment:
+
+```jsonc
+"Plugins": {
+  "Repositories": [ "https://raw.githubusercontent.com/ArgonFetch/ArgonFetchPlugins/repo/index.json" ],
+  "Install": [ "spotify", "tiktok" ]
+}
+```
+
+The list is read as **desired state**: what you name is installed, what you leave out is
+removed. Pin a version with `spotify@1.0.0`, or name the plugin alone for the newest build
+that fits this release.
+
+The order is also precedence - if two plugins claim the same link, the one listed first
+wins, and the other is mentioned in the log so you can see it happened.
+
+Plugins are downloaded once at startup and checked against the hash the repository
+published, never during a request. A repository that cannot be reached leaves whatever is
+already installed alone rather than stopping the app from starting.
+
+Anyone can serve a repository: it is a JSON index and some zip files on a URL. To write a
+plugin, start from
+[ArgonFetchPluginTemplate](https://github.com/ArgonFetch/ArgonFetchPluginTemplate).
 
 ## CORS
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -6,6 +6,8 @@ Paste a URL, and ArgonFetch resolves it, lists every quality the source actually
 serves the one you pick back as an ordinary browser download. There is nothing to sign up for
 and nothing to configure - not even Spotify credentials.
 
+- **Plugins.** Sources yt-dlp cannot reach - Spotify, TikTok - are installed by name rather than
+  built in, and anyone can publish one.
 - **No API keys.** Spotify metadata is read from the public track page, so there is no developer
   app to register and no secret to rotate.
 - **Audio or video.** Renditions come straight from the source, with a size and bitrate on each

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -1,9 +1,11 @@
 # Supported platforms
 
-Extraction runs on [`yt-dlp`](https://github.com/yt-dlp/yt-dlp) plus ArgonFetch's own extractors
-on top of it, so a link from almost any site yt-dlp knows will resolve, and the sites it does not
-handle well get their own handling here - Spotify is the clearest case, resolved from the public
-track page rather than by yt-dlp at all.
+Extraction runs on [`yt-dlp`](https://github.com/yt-dlp/yt-dlp), so a link from almost any site
+it knows will resolve. The sites yt-dlp does not handle are covered by **plugins** - Spotify is
+the clearest case, resolved from the public track page rather than by yt-dlp at all.
+
+Plugins are installed by name and are not built in, so Spotify and TikTok need two lines of
+[configuration](/configuration#plugins) before they work.
 
 The table below is the shorter list that ArgonFetch tests and supports directly. Anything outside
 it is worth trying, but is not something we chase when it breaks.
@@ -11,15 +13,15 @@ it is worth trying, but is not something we chase when it breaks.
 | Platform | Status | Notes |
 |---|---|---|
 | YouTube | ✅ Video and audio | Muxes separate video/audio streams when no pre-muxed format exists |
-| Spotify | ✅ Tracks, playlists and albums | Metadata is read from the public pages; audio comes from the matching YouTube Music result |
-| TikTok | ✅ | |
+| Spotify | ✅ Tracks, playlists and albums | Needs the `spotify` [plugin](/configuration#plugins). Metadata is read from the public pages; audio comes from the matching YouTube Music result |
+| TikTok | ✅ | Needs the `tiktok` [plugin](/configuration#plugins) |
 | SoundCloud | ✅ | Except the licensed catalogue, which is DRM protected and refused - see [below](#drm-protected-tracks) |
 | Instagram | ⚠️ Needs a signed-in session | Instagram serves media only to logged-in accounts. Point [`COOKIES_PATH`](/configuration) at an exported session and it works |
 | Playlists | ✅ Any source | Resolved as a collection; download the tracks individually or the whole list as one zip |
 
 ## Spotify without an API key
 
-Spotify links do not need credentials. ArgonFetch reads the title, artist and cover from the
+Spotify links need the `spotify` plugin installed, but no credentials. ArgonFetch reads the title, artist and cover from the
 public track page, then finds the matching result on YouTube Music and streams the audio from
 there. There is no developer app to register and no secret to rotate.
 
@@ -42,7 +44,9 @@ Instagram serves media only to a signed-in session, so a link that opens fine in
 returns nothing to a server that is not logged in. This is not a bug in the extractor and no
 retry will help - the request never had the credentials it needed.
 
-ArgonFetch has no way to supply them today, so Instagram links do not work.
+Point [`COOKIES_PATH`](/configuration) at a Netscape-format cookies file exported from a
+signed-in browser and the session travels with the fetch. Without it, the request never had the
+credentials it needed and no retry will help.
 
 ## When a platform stops working
 

--- a/src/ArgonFetch.API/Controllers/FetchController.cs
+++ b/src/ArgonFetch.API/Controllers/FetchController.cs
@@ -29,13 +29,8 @@ namespace ArgonFetch.API.Controllers
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status415UnsupportedMediaType)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status502BadGateway)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status503ServiceUnavailable)]
-        // Marked required rather than merely being non-nullable: binding already refused a
-        // call without it, but the generated schema said the parameter was optional, so every
-        // client built from it offered a request the API will only ever answer with a 400.
         public async Task<ActionResult<ResourceInformationDto>> GetResource([FromQuery][Required] string url)
         {
-            // Refused rather than attempted: the yt-dlp binary is being replaced underneath us,
-            // and the error that produces looks like a broken source rather than a busy server.
             if (_maintenance.Activity is { } activity)
             {
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, new ProblemDetails
@@ -69,8 +64,6 @@ namespace ArgonFetch.API.Controllers
                 return StatusCode(StatusCodes.Status415UnsupportedMediaType, new ProblemDetails
                 {
                     Title = "Unsupported Media Type",
-                    // Carried through so a caller learns which kind of unsupported this is -
-                    // DRM, or a link shape ArgonFetch does not handle yet.
                     Detail = ex.Message,
                     Status = StatusCodes.Status415UnsupportedMediaType
                 });

--- a/src/ArgonFetch.API/Controllers/StreamController.cs
+++ b/src/ArgonFetch.API/Controllers/StreamController.cs
@@ -12,11 +12,8 @@ namespace ArgonFetch.API.Controllers
     [Route("api/[controller]")]
     public class StreamController : ControllerBase
     {
-        // Often enough to look live against tracks that take seconds each, seldom enough that a
-        // watcher costs nothing to keep open.
         private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
 
-        // A watcher whose archive never reports again is dropped rather than held forever.
         private static readonly TimeSpan MaxWatchTime = TimeSpan.FromMinutes(30);
 
         private static readonly JsonSerializerOptions JsonOptions =
@@ -34,7 +31,6 @@ namespace ArgonFetch.API.Controllers
         }
 
         [HttpGet("Combined/{key}", Name = "Combined")]
-        // Muxed on the fly, so its length is unknown and it cannot be seeked within.
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> StreamCombinedMedia([FromRoute] string key, CancellationToken cancellationToken)
@@ -42,7 +38,6 @@ namespace ArgonFetch.API.Controllers
             var query = new StreamCombinedMediaQuery(key, Response, cancellationToken);
             var result = await _mediator.Send(query, cancellationToken);
 
-            // Handle the result if response hasn't started
             if (!Response.HasStarted && !result.IsSuccess && result.StatusCode.HasValue)
             {
                 Response.StatusCode = result.StatusCode.Value;
@@ -53,20 +48,10 @@ namespace ArgonFetch.API.Controllers
             return new EmptyResult();
         }
 
-        /// <summary>
-        /// Every track of a playlist or album, as one zip.
-        /// </summary>
-        /// <param name="url">Link to the collection, the same one the fetch endpoint takes.</param>
         [HttpGet("Archive", Name = "Archive")]
-        // Built while it is sent, so it declares no length and cannot be seeked within.
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        /// <param name="jobId">
-        /// Optional id to publish progress against, chosen by the caller. Pass the same one to
-        /// the progress endpoint to watch the archive being built. Omit it and nothing is
-        /// published, which is what a plain download does not need.
-        /// </param>
         public async Task<IActionResult> StreamArchive(
             [FromQuery][Required] string url,
             CancellationToken cancellationToken,
@@ -94,19 +79,12 @@ namespace ArgonFetch.API.Controllers
             return new EmptyResult();
         }
 
-
-        /// <summary>
-        /// How far along an archive is, as server-sent events, until it finishes.
-        /// </summary>
-        /// <param name="jobId">The id passed to the archive request whose progress to follow.</param>
         [HttpGet("Archive/Progress/{jobId}", Name = "ArchiveProgress")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task ArchiveProgress([FromRoute] string jobId, CancellationToken cancellationToken)
         {
             Response.ContentType = "text/event-stream";
             Response.Headers.CacheControl = "no-cache";
-            // Nginx buffers a response by default, which holds every event back until the end and
-            // makes a live progress feed arrive all at once when there is nothing left to show.
             Response.Headers["X-Accel-Buffering"] = "no";
 
             var deadline = DateTimeOffset.UtcNow.Add(MaxWatchTime);
@@ -116,8 +94,6 @@ namespace ArgonFetch.API.Controllers
             {
                 var current = _archiveProgress.Get(jobId);
 
-                // Sent only when something changed, so a slow track does not fill the connection
-                // with repetitions of the same number.
                 if (current is not null && current != last)
                 {
                     await Response.WriteAsync($"data: {JsonSerializer.Serialize(current, JsonOptions)}\n\n", cancellationToken);
@@ -133,10 +109,6 @@ namespace ArgonFetch.API.Controllers
             }
         }
 
-        /// <param name="format">
-        /// Optional container to convert to, currently only "mp3". Omit it to receive the
-        /// source untouched, which is faster and avoids a re-encode.
-        /// </param>
         [HttpGet("Media/{key}", Name = "Media")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status206PartialContent)]
@@ -144,12 +116,9 @@ namespace ArgonFetch.API.Controllers
         [ProducesResponseType(StatusCodes.Status416RangeNotSatisfiable)]
         public async Task<IActionResult> StreamMedia([FromRoute] string key, CancellationToken cancellationToken, [FromQuery] string? format = null)
         {
-            // The Range header is read here rather than in the handler so the query stays
-            // something that can be constructed without an HttpRequest.
             var query = new StreamMediaQuery(key, Response, cancellationToken, format, Request.Headers.Range);
             var result = await _mediator.Send(query, cancellationToken);
 
-            // Handle the result if response hasn't started
             if (!Response.HasStarted && !result.IsSuccess && result.StatusCode.HasValue)
             {
                 Response.StatusCode = result.StatusCode.Value;

--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -9,7 +9,6 @@ using YoutubeDLSharp;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Load .env file if it exists (for local development)
 if (File.Exists(".env"))
 {
     foreach (var line in File.ReadAllLines(".env"))
@@ -27,24 +26,15 @@ if (File.Exists(".env"))
 }
 
 #region Configure Services
-// Add services to the container.
-// Enums are serialized by name so the wire format stays stable when members are
-// reordered, and clients don't have to mirror the numeric values.
 builder.Services.AddControllers()
     .AddJsonOptions(o =>
         o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 builder.Services.AddSpaStaticFiles(spaStaticFilesOptions => { spaStaticFilesOptions.RootPath = "wwwroot/browser"; });
 
-// Handlers are wired up at compile time by the source generator rather than found by
-// reflection at startup, so a handler that does not exist is a build error rather than a
-// request that fails once somebody makes it.
 builder.Services.AddMediator(options => options.ServiceLifetime = ServiceLifetime.Scoped);
 
-// Register In memory caching
 builder.Services.AddMemoryCache();
 
-// yt-dlp is fetched when the app boots and kept current from there, so the image ships
-// without it and a restart is enough to pick up an extractor fix.
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IToolPaths>(
     new ArgonFetch.Application.Services.ToolPaths(
         builder.Configuration["TOOLS_PATH"],
@@ -53,12 +43,10 @@ builder.Services.AddSingleton<ArgonFetch.Infrastructure.Services.MediaToolsServi
 builder.Services.AddHostedService(
     sp => sp.GetRequiredService<ArgonFetch.Infrastructure.Services.MediaToolsService>());
 
-// Register Application Info Service
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IApplicationInfoService, ArgonFetch.Infrastructure.Services.ApplicationInfoService>();
 #endregion
 
 #region API Documentation
-// Register Swagger services
 builder.Services.AddSwaggerGen();
 builder.Services.AddEndpointsApiExplorer();
 #endregion
@@ -79,10 +67,8 @@ builder.Services.AddScoped(sp =>
     };
 });
 
-// Register FFmpeg and streaming services
 builder.Services.AddHttpClient();
 
-// Client used for all upstream media fetches; carries the User-Agent that avoids 403s.
 builder.Services.AddHttpClient(
     ArgonFetch.Application.Services.MediaHttpClientDefaults.ClientName,
     client => client.DefaultRequestHeaders.UserAgent.ParseAdd(
@@ -95,9 +81,7 @@ builder.Services.AddScoped<ArgonFetch.Application.Services.IProxyUrlBuilder, Arg
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IMediaUrlCacheService, ArgonFetch.Application.Services.MediaUrlCacheService>();
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IMediaHttpClients, ArgonFetch.Application.Services.MediaHttpClients>();
 
-// Lets the app tell clients it is briefly busy (updating yt-dlp) instead of failing fetches.
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IMaintenanceState, ArgonFetch.Application.Services.MaintenanceState>();
-// Singleton so an archive being built by one request can be read by the request watching it.
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IArchiveProgressTracker, ArgonFetch.Application.Services.ArchiveProgressTracker>();
 
 // Optional proxy list (one proxy per line) rotated across yt-dlp fetches; no file means direct fetches.
@@ -107,7 +91,6 @@ builder.Services.AddSingleton<ArgonFetch.Application.Services.IProxyPool>(sp =>
 #endregion
 
 #region Validation
-// Register FluentValidation
 builder.Services.AddFluentValidationAutoValidation();
 #region Plugins
 // Read as desired state: what the configuration lists is installed, what it does not is removed.
@@ -121,8 +104,6 @@ builder.Services.AddSingleton<ArgonFetch.Application.Plugins.PluginLoader>();
 builder.Services.AddSingleton<ArgonFetch.Application.Plugins.IProviderContextFactory,
     ArgonFetch.Application.Plugins.ProviderContextFactory>();
 
-// Loaded once. Providers are asked on every request, so building them per request would pay
-// reflection over and over for an answer that cannot change while the process is running.
 builder.Services.AddSingleton<ArgonFetch.Application.Plugins.IProviderRegistry>(serviceProvider =>
 {
     var loader = serviceProvider.GetRequiredService<ArgonFetch.Application.Plugins.PluginLoader>();
@@ -142,16 +123,11 @@ builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBeh
 #endregion
 
 #region CORS Configuration
-// Configure CORS with environment variable support
 const string defaultCorsOrigin = "http://localhost:4200";
 
-// Get allowed origins from environment variable only
 var allowedOrigins = Environment.GetEnvironmentVariable("CORS_ALLOWED_ORIGINS")?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
     ?? new[] { defaultCorsOrigin }; // Default for development
 
-// In production, ensure we have proper origins configured. The warning is emitted
-// after the host is built so it can use the application's own logger - resolving
-// one here would require building a second service provider (ASP0000).
 var corsUsesDevelopmentDefault = allowedOrigins.Length == 1 && allowedOrigins[0] == defaultCorsOrigin;
 
 builder.Services.AddCors(options =>
@@ -177,9 +153,6 @@ var app = builder.Build();
 #region Startup Diagnostics
 var startupLogger = app.Services.GetRequiredService<ILogger<Program>>();
 
-// Before the registry is ever resolved, so what is on disk is what was asked for by the time
-// anything looks. Deliberately at startup and never during a request: software that installs
-// itself halfway through a download is not something anyone wants to debug.
 {
     var pluginRoot = Path.IsPathRooted(pluginOptions.Path)
         ? pluginOptions.Path
@@ -200,13 +173,11 @@ if (app.Environment.IsProduction() && corsUsesDevelopmentDefault)
     startupLogger.LogWarning("CORS is using default localhost origin in production. Please set CORS_ALLOWED_ORIGINS environment variable.");
 }
 
-// Logged so a mistyped PROXY_LIST_PATH shows up at startup rather than as silent direct fetches.
 startupLogger.LogInformation("Proxy rotation: {Count} proxies loaded",
     app.Services.GetRequiredService<ArgonFetch.Application.Services.IProxyPool>().Count);
 #endregion
 
 #region Configure HTTP Pipeline
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -216,29 +187,18 @@ if (app.Environment.IsDevelopment())
     });
 }
 
-
 app.UseStaticFiles();
 
 if (!app.Environment.IsDevelopment())
 {
-    // Don't use HTTPS redirection in production when running behind a reverse proxy
-    // The proxy handles HTTPS termination
-    // app.UseHttpsRedirection();
     app.UseSpaStaticFiles();
 }
 
-// Ensure frontend routes work
 app.UseRouting();
 app.UseAuthorization();
 app.UseCors();
 app.MapControllers();
 
-// An unmatched /api path is a client error, not a page. UseSpa below is terminal and answers
-// anything routing did not match with index.html, which for an API path means a caller gets
-// 200 and a page of HTML instead of a 404 - a parse error rather than a status they can act
-// on. Registered as a fallback so it is chosen only when no controller matched, and the SPA
-// middleware passes through any request that already has an endpoint, so every non-API path
-// still reaches the client router untouched.
 app.MapFallback("/api/{**path}", (HttpContext context) => Results.Problem(
     title: "Not Found",
     detail: $"No endpoint matches {context.Request.Path}.",
@@ -246,7 +206,6 @@ app.MapFallback("/api/{**path}", (HttpContext context) => Results.Problem(
 #endregion
 
 #region SPA Configuration
-// Serve Angular Frontend in Production
 if (!app.Environment.IsDevelopment())
 {
     app.UseSpa(spa =>

--- a/src/ArgonFetch.API/appsettings.Development.json
+++ b/src/ArgonFetch.API/appsettings.Development.json
@@ -6,7 +6,9 @@
     }
   },
   "Plugins": {
-    "Repositories": [],
+    "Repositories": [
+      "https://raw.githubusercontent.com/ArgonFetch/ArgonFetchPlugins/repo/index.json"
+    ],
     "Install": [
       "spotify",
       "tiktok"

--- a/src/ArgonFetch.Abstractions/ArgonFetchPluginAttribute.cs
+++ b/src/ArgonFetch.Abstractions/ArgonFetchPluginAttribute.cs
@@ -1,13 +1,5 @@
 namespace ArgonFetch.Abstractions
 {
-    /// <summary>
-    /// Marks an assembly as an ArgonFetch plugin and states which contract it was built against.
-    /// <para>
-    /// Read before anything in the assembly is instantiated, so a plugin written for a contract
-    /// this host does not implement is set aside with a line in the log rather than loaded and
-    /// discovered halfway through a request.
-    /// </para>
-    /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
     public sealed class ArgonFetchPluginAttribute : Attribute
     {
@@ -17,20 +9,12 @@ namespace ArgonFetch.Abstractions
             Abi = abi;
         }
 
-        /// <summary>The id this plugin is installed and configured under.</summary>
         public string Id { get; }
 
-        /// <summary>
-        /// Major version of ArgonFetch.Abstractions this was built against. The host implements
-        /// exactly one, and refuses anything else - a contract that changed shape is not
-        /// something to guess at.
-        /// </summary>
         public int Abi { get; }
 
-        /// <summary>Shown to an operator choosing what to install.</summary>
         public string? Name { get; init; }
 
-        /// <summary>The current contract, for a plugin that does not want to spell out a number.</summary>
         public const int CurrentAbi = 1;
     }
 }

--- a/src/ArgonFetch.Abstractions/IProviderContext.cs
+++ b/src/ArgonFetch.Abstractions/IProviderContext.cs
@@ -3,14 +3,6 @@ using Microsoft.Extensions.Logging;
 
 namespace ArgonFetch.Abstractions
 {
-    /// <summary>
-    /// What the host lends a provider.
-    /// <para>
-    /// Capabilities, never the container. Handing over a service provider would make every type
-    /// the host happens to register part of this contract, and the first plugin to reach for one
-    /// would freeze it there.
-    /// </para>
-    /// </summary>
     public interface IProviderContext
     {
         /// <summary>
@@ -23,39 +15,14 @@ namespace ArgonFetch.Abstractions
         /// </param>
         HttpClient CreateHttpClient(bool rotateProxy = true);
 
-        /// <summary>
-        /// Shared with the rest of the application, so a plugin must key entries with something
-        /// of its own. <see cref="CacheKey"/> does that.
-        /// </summary>
         IMemoryCache Cache { get; }
 
-        /// <summary>Named for the plugin, so its lines are attributable in a shared log.</summary>
         ILogger Logger { get; }
 
-        /// <summary>
-        /// Settings the operator wrote for this plugin, from the configuration section named
-        /// after it. Empty when none were given - a plugin that needs one has to say so itself.
-        /// </summary>
         IReadOnlyDictionary<string, string?> Settings { get; }
 
-        /// <summary>
-        /// What the fetch engine can say about a link without downloading it.
-        /// <para>
-        /// For choosing between candidates: a provider that has found several possible matches
-        /// for a recording can ask how long each one runs and keep the one that fits. Null when
-        /// the link cannot be read at all, which is an answer rather than a fault.
-        /// </para>
-        /// <para>
-        /// The result is remembered for the length of the request, so probing a link and then
-        /// handing that same link back as a rewrite does not fetch it twice.
-        /// </para>
-        /// </summary>
         Task<ProbeResult?> ProbeAsync(Uri url, CancellationToken cancellationToken);
 
-        /// <summary>
-        /// A cache key belonging to this plugin, so two plugins caching "track:1" do not
-        /// overwrite each other.
-        /// </summary>
         string CacheKey(string key);
     }
 }

--- a/src/ArgonFetch.Abstractions/ISourceProvider.cs
+++ b/src/ArgonFetch.Abstractions/ISourceProvider.cs
@@ -1,23 +1,7 @@
 namespace ArgonFetch.Abstractions
 {
-    /// <summary>
-    /// A source ArgonFetch does not already know how to fetch.
-    /// <para>
-    /// yt-dlp is what fetches things the ordinary way, and most links need nothing more than
-    /// that. A provider exists for the links that do: one that has to be turned into a different
-    /// link before anything can be downloaded, one that lists a collection, or one that a
-    /// separate piece of code fetches entirely on its own.
-    /// </para>
-    /// </summary>
     public interface ISourceProvider
     {
-        /// <summary>
-        /// Stable name for this provider, matching the id it is installed under - "spotify".
-        /// <para>
-        /// It is how an operator asks for the plugin and how conflicts between two providers are
-        /// settled, so renaming one is a breaking change to somebody's configuration.
-        /// </para>
-        /// </summary>
         string Id { get; }
 
         /// <summary>
@@ -36,60 +20,24 @@ namespace ArgonFetch.Abstractions
         /// <example><c>[@"^https?://([\w-]+\.)*spotify\.com/"]</c></example>
         IReadOnlyList<string> UrlPatterns { get; }
 
-        /// <summary>
-        /// A second opinion, once a pattern has already matched.
-        /// <para>
-        /// Almost no provider needs this - the patterns are usually the whole answer, and the
-        /// default accepts whatever they matched. Override it when the URL alone decides
-        /// something a regular expression should not be asked to express.
-        /// </para>
-        /// <para>
-        /// Must be cheap, must not touch the network, and must not throw: it is asked on every
-        /// request for a link this provider claimed. That is why it is not asynchronous - an
-        /// awaitable signature invites a request nobody meant to make.
-        /// </para>
-        /// </summary>
         bool CanHandle(Uri url) => true;
 
-        /// <summary>
-        /// What should happen to the link. See <see cref="ProviderOutcome"/> for the four answers.
-        /// </summary>
         Task<ProviderOutcome> PrepareAsync(Uri url, IProviderContext context, CancellationToken cancellationToken);
     }
 
-    /// <summary>
-    /// Adjusts how yt-dlp is invoked, for sources that are fetched the ordinary way but need
-    /// something said first - a session to prove who is asking, a particular container.
-    /// <para>
-    /// Separate from <see cref="ISourceProvider"/> because it composes: several hooks may apply
-    /// to one fetch, where exactly one provider ever handles a link.
-    /// </para>
-    /// </summary>
     public interface IFetchOptionsHook
     {
-        /// <summary>
-        /// Called before every fetch, for every link. Change only what this hook is for and
-        /// leave the rest alone - the next hook in line is looking at the same object.
-        /// </summary>
         void Configure(IFetchOptions options, Uri url);
     }
 
-    /// <summary>
-    /// The parts of a yt-dlp invocation a plugin may change. Deliberately not the whole option
-    /// set: everything exposed here is something the host promises to keep meaning the same.
-    /// </summary>
     public interface IFetchOptions
     {
-        /// <summary>Path to a cookies file, for a source that serves nothing to strangers.</summary>
         string? CookiesPath { get; set; }
 
-        /// <summary>Proxy to fetch through. Already set from the rotating pool; replacing it opts out of that.</summary>
         string? Proxy { get; set; }
 
-        /// <summary>yt-dlp format selector, when the default pick is wrong for a source.</summary>
         string? Format { get; set; }
 
-        /// <summary>An <c>--extractor-args</c> entry, e.g. <c>("youtube", "player_client=web")</c>.</summary>
         void SetExtractorArgument(string extractor, string argument);
     }
 }

--- a/src/ArgonFetch.Abstractions/ProviderOutcome.cs
+++ b/src/ArgonFetch.Abstractions/ProviderOutcome.cs
@@ -1,44 +1,20 @@
 namespace ArgonFetch.Abstractions
 {
-    /// <summary>
-    /// What a provider decided to do with a link. There are four answers and no others.
-    /// </summary>
     public abstract record ProviderOutcome
     {
         private ProviderOutcome() { }
 
-        /// <summary>
-        /// Nothing to do - let yt-dlp fetch the original link. Also the right answer when a
-        /// provider recognises the link but finds nothing special about this particular one.
-        /// </summary>
         public static ProviderOutcome PassThrough { get; } = new PassThroughOutcome();
 
-        /// <summary>
-        /// Fetch a different link instead, and describe the result with these tags.
-        /// <para>
-        /// Spotify serves no audio anyone can download, so its provider finds the same recording
-        /// elsewhere and points the fetch at that - while keeping Spotify's own title and credit,
-        /// which are the reason the track was matched rather than merely searched for.
-        /// </para>
-        /// </summary>
         public static ProviderOutcome Rewrite(Uri url, MediaTags tags, string? coverUrl = null) =>
             new RewriteOutcome(url, tags, coverUrl);
 
-        /// <summary>
-        /// The link names a collection. Entries are listed, not resolved - each one is fetched
-        /// through the ordinary path when somebody actually asks for it, because resolving a
-        /// thousand of them to show a list would take the better part of an hour.
-        /// </summary>
         public static ProviderOutcome Listing(CollectionResult collection) =>
             new ListingOutcome(collection);
 
-        /// <summary>
-        /// The provider fetched it. yt-dlp is not run at all.
-        /// </summary>
         public static ProviderOutcome Complete(MediaResult media) =>
             new CompleteOutcome(media);
 
-        /// <summary>Not this provider's link after all - try the next one, then yt-dlp.</summary>
         public static ProviderOutcome Declined { get; } = new DeclinedOutcome();
 
         public sealed record PassThroughOutcome : ProviderOutcome;

--- a/src/ArgonFetch.Abstractions/Results.cs
+++ b/src/ArgonFetch.Abstractions/Results.cs
@@ -1,75 +1,36 @@
 namespace ArgonFetch.Abstractions
 {
-    /// <summary>
-    /// What a downloaded file should say it is. Carried from whatever identified the media to
-    /// whatever serves it.
-    /// </summary>
     public sealed record MediaTags(string? Title, string? Artist);
 
-    /// <summary>
-    /// A collection, as a list of links and what little is known about each.
-    /// </summary>
     public sealed record CollectionResult(
         string? Title,
         string? Author,
         string? CoverUrl,
         IReadOnlyList<CollectionEntry> Items)
     {
-        /// <summary>
-        /// Whether the source is known to have sent only part of the list. Reported rather than
-        /// hidden: a listing that quietly stops at a hundred looks exactly like a hundred-entry
-        /// collection, and nobody notices what is missing.
-        /// </summary>
         public bool MayBeTruncated { get; init; }
     }
 
-    /// <summary>
-    /// One entry of a collection. Deliberately not resolved - the link is enough, and following
-    /// it is what happens when somebody picks this entry.
-    /// </summary>
     public sealed record CollectionEntry(Uri Url, string Title, string? Author = null, string? CoverUrl = null);
 
-    /// <summary>
-    /// Media a provider fetched by itself.
-    /// </summary>
     public sealed record MediaResult(
         string Title,
         string? Author,
         string? CoverUrl,
         IReadOnlyList<MediaStream> Streams);
 
-    /// <summary>
-    /// One downloadable stream, as the source serves it.
-    /// <para>
-    /// A plain address and what is known about it, nothing more. Caching it, hiding it behind a
-    /// key and building the URL a client is given are all the host's business - a plugin that
-    /// did any of that would be coupled to how the host serves bytes, which changes.
-    /// </para>
-    /// </summary>
     public sealed record MediaStream(Uri Url, bool IsAudio)
     {
-        /// <summary>Shown to whoever is choosing, e.g. "1080p" or "128 kbps".</summary>
         public string? Label { get; init; }
 
-        /// <summary>Media type of the bytes at <see cref="Url"/>, where the source declares one.</summary>
         public string? MimeType { get; init; }
 
-        /// <summary>Extension the file should be saved as, including the dot.</summary>
         public string? FileExtension { get; init; }
 
-        /// <summary>Transfer size where the source reports one; it is what tells a reader how long this will take.</summary>
         public long? SizeBytes { get; init; }
 
-        /// <summary>
-        /// Proxy this address was obtained through, when it was. Sources commonly sign an address
-        /// for the address that asked for it, so fetching it from anywhere else is refused.
-        /// </summary>
         public string? Proxy { get; init; }
     }
 
-    /// <summary>
-    /// The little that can be learned about a link without downloading it. Enough to tell one
-    /// candidate recording from another, which is what it is for.
-    /// </summary>
     public sealed record ProbeResult(string? Title, string? Uploader, double? DurationSeconds);
 }

--- a/src/ArgonFetch.Application/Dtos/AppInfoDto.cs
+++ b/src/ArgonFetch.Application/Dtos/AppInfoDto.cs
@@ -6,10 +6,6 @@
         public required bool IsHealthy { get; set; }
         public required string Environment { get; set; }
 
-        /// <summary>
-        /// What the server is busy with, or null when it is serving normally. Clients show it
-        /// as a maintenance screen instead of letting fetches fail in confusing ways.
-        /// </summary>
         public string? Maintenance { get; set; }
 
     }

--- a/src/ArgonFetch.Application/Dtos/MediaInformationDto.cs
+++ b/src/ArgonFetch.Application/Dtos/MediaInformationDto.cs
@@ -4,13 +4,10 @@
     {
         public required string RequestedUrl { get; set; }
 
-        // Video with audio (either pre-muxed or will be combined via FFmpeg if needed)
         public StreamReferenceDto? Video { get; set; }
 
-        // Audio-only option
         public StreamReferenceDto? Audio { get; set; }
 
-        /// <summary>Cover art, where the source has any.</summary>
         public string? CoverUrl { get; set; }
         public required string Title { get; set; }
         public required string Author { get; set; }

--- a/src/ArgonFetch.Application/Dtos/MediaRenditionDto.cs
+++ b/src/ArgonFetch.Application/Dtos/MediaRenditionDto.cs
@@ -2,55 +2,26 @@
 
 namespace ArgonFetch.Application.Dtos
 {
-    /// <summary>
-    /// One downloadable version of a media item.
-    /// <para>
-    /// Replaces reasoning in terms of "best", "medium" and "worst": those three were whatever
-    /// happened to sit at the ends and the middle of the source's format list, so the same label
-    /// meant something different from one item to the next. A caller picks from these instead,
-    /// with the size on hand to judge how long it will take.
-    /// </para>
-    /// </summary>
     public class MediaRenditionDto
     {
-        /// <summary>Cache key to stream this rendition with.</summary>
         public required string Key { get; set; }
 
-        /// <summary>
-        /// Short label for a picker, e.g. "1080p" or "160 kbps". Derived from the resolution or
-        /// bitrate rather than the source's own wording, which is not written for readers.
-        /// </summary>
         public required string Label { get; set; }
 
-        /// <summary>The source's own description of the format, kept for the curious.</summary>
         public string? Description { get; set; }
 
         public required string FileExtension { get; set; }
 
-        /// <summary>Media type of the bytes this rendition will deliver.</summary>
         public required string MimeType { get; set; }
 
-        /// <summary>Which stream endpoint serves it - muxing is not the same route as passing bytes through.</summary>
         public UrlType UrlType { get; set; }
 
-        /// <summary>
-        /// Transfer size in bytes where the source reports one, so a caller can sort by how fast
-        /// a rendition will arrive rather than inferring it from the resolution. Null when the
-        /// source does not say, which is the norm for anything that has to be muxed.
-        /// </summary>
         public long? FileSizeBytes { get; set; }
 
-        /// <summary>Vertical resolution for video renditions, null for audio.</summary>
         public int? Height { get; set; }
 
-        /// <summary>Bitrate in kbps where known.</summary>
         public double? Bitrate { get; set; }
 
-        /// <summary>
-        /// Container the server converts to before sending, or null when the source bytes are
-        /// passed through untouched. Clients pass it back as the stream endpoint's format
-        /// parameter, so a converted option needs no special case of its own.
-        /// </summary>
         public string? ConvertTo { get; set; }
     }
 }

--- a/src/ArgonFetch.Application/Dtos/ResourceInformationDto.cs
+++ b/src/ArgonFetch.Application/Dtos/ResourceInformationDto.cs
@@ -6,11 +6,6 @@ namespace ArgonFetch.Application.Dtos
     {
         public required MediaType Type { get; set; }
 
-        /// <summary>
-        /// The link this was resolved from. Echoed back because a collection is addressed by it
-        /// elsewhere - the archive endpoint takes it - and the individual entries carry only
-        /// their own links, not the one that produced the listing.
-        /// </summary>
         public string? RequestedUrl { get; set; }
 
         public string? Title { get; set; }

--- a/src/ArgonFetch.Application/Dtos/StreamReferenceDto.cs
+++ b/src/ArgonFetch.Application/Dtos/StreamReferenceDto.cs
@@ -2,24 +2,10 @@
 
 namespace ArgonFetch.Application.Dtos
 {
-    /// <summary>
-    /// The downloadable versions of one media item, and which stream endpoint serves them.
-    /// </summary>
     public class StreamReferenceDto
     {
-        /// <summary>Which stream endpoint serves these - muxing is not the same route as passing bytes through.</summary>
         public UrlType UrlType { get; set; }
 
-        /// <summary>
-        /// Every rendition on offer, best first.
-        /// <para>
-        /// This used to sit beside a fixed "best", "medium" and "worst" triple, which was the
-        /// first, middle and last of this list. Those three were whatever happened to fall at
-        /// the ends and the middle of the source's format list, so the same label meant a
-        /// different thing from one item to the next, and a source offering eleven versions was
-        /// described with the same three rungs as one offering two. Callers pick from the list.
-        /// </para>
-        /// </summary>
         public List<MediaRenditionDto> Renditions { get; set; } = [];
     }
 }

--- a/src/ArgonFetch.Application/Exceptions/UnknownContentTypeException.cs
+++ b/src/ArgonFetch.Application/Exceptions/UnknownContentTypeException.cs
@@ -1,30 +1,15 @@
 ﻿namespace ArgonFetch.Application.Exceptions
 {
-    /// <summary>
-    /// Exception thrown when an unknown or unsupported content type is encountered.
-    /// </summary>
     public class UnknownContentTypeException : System.Exception
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UnknownContentTypeException"/> class.
-        /// </summary>
         public UnknownContentTypeException() : base("Unknown or unsupported content type.")
         {
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UnknownContentTypeException"/> class with a specified error message.
-        /// </summary>
-        /// <param name="message">The message that describes the error.</param>
         public UnknownContentTypeException(string message) : base(message)
         {
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UnknownContentTypeException"/> class with a specified error message and inner exception.
-        /// </summary>
-        /// <param name="message">The message that describes the error.</param>
-        /// <param name="innerException">The exception that caused the current exception.</param>
         public UnknownContentTypeException(string message, System.Exception innerException) : base(message, innerException)
         {
         }

--- a/src/ArgonFetch.Application/Interfaces/IAcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Application/Interfaces/IAcceleratedDownloadService.cs
@@ -16,10 +16,6 @@ namespace ArgonFetch.Application.Interfaces
             ByteRange? range = null,
             CancellationToken cancellationToken = default);
 
-        /// <summary>
-        /// Length the upstream reports for the resource, or null when it does not report one.
-        /// Callers use it to declare Content-Length on a pass-through response.
-        /// </summary>
         Task<long?> GetContentLengthAsync(
             string url,
             string? proxy = null,

--- a/src/ArgonFetch.Application/Plugins/PluginInstaller.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginInstaller.cs
@@ -6,13 +6,6 @@ using Microsoft.Extensions.Logging;
 
 namespace ArgonFetch.Application.Plugins
 {
-    /// <summary>
-    /// Makes the plugins folder match what was asked for.
-    /// <para>
-    /// Runs once at startup and never during a request: a download that quietly installs software
-    /// halfway through is not something anyone wants to debug.
-    /// </para>
-    /// </summary>
     public class PluginInstaller
     {
         private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
@@ -51,9 +44,6 @@ namespace ArgonFetch.Application.Plugins
                 }
                 catch (Exception ex)
                 {
-                    // A plugin that cannot be installed must not stop the application: the rest
-                    // of it still works, and refusing to start would take a whole downloader
-                    // offline because one source's repository is having a bad morning.
                     _logger.LogError(ex, "Could not install the {Id} plugin", id);
                 }
             }
@@ -70,9 +60,6 @@ namespace ArgonFetch.Application.Plugins
 
             if (!index.TryGetValue(id, out var candidates))
             {
-                // Already present and no index to check it against is a working setup, not a
-                // failure - which is what keeps an unreachable repository from taking the
-                // application down with it.
                 if (installed is not null)
                 {
                     _logger.LogInformation("Keeping the {Id} plugin at {Version}; no repository listed it", id, installed);
@@ -120,8 +107,6 @@ namespace ArgonFetch.Application.Plugins
 
             var folder = Path.Combine(root, entry.Id);
 
-            // Replaced rather than merged: leaving an older build's files behind is how a plugin
-            // ends up loading half of one version and half of another.
             if (Directory.Exists(folder))
                 Directory.Delete(folder, recursive: true);
 
@@ -158,10 +143,6 @@ namespace ArgonFetch.Application.Plugins
                         if (string.IsNullOrWhiteSpace(entry.Id))
                             continue;
 
-                        // Two repositories offering the same id makes the configuration
-                        // ambiguous - "spotify" would mean different software depending on
-                        // which repository answered first. The one listed earlier wins, and
-                        // the clash is said out loud rather than resolved quietly.
                         if (index.TryGetValue(entry.Id, out var existing) && existing[0].Item2 != uri)
                         {
                             _logger.LogWarning(
@@ -185,7 +166,6 @@ namespace ArgonFetch.Application.Plugins
             return index;
         }
 
-        /// <summary>Removes anything installed that is no longer asked for.</summary>
         private void Prune(string root, HashSet<string> wanted)
         {
             foreach (var folder in Directory.GetDirectories(root))
@@ -215,7 +195,6 @@ namespace ArgonFetch.Application.Plugins
             return File.Exists(marker) ? File.ReadAllText(marker).Trim() : null;
         }
 
-        /// <summary>Splits "spotify" or "spotify@1.2.0".</summary>
         internal static (string Id, string? Version)? Parse(string request)
         {
             if (string.IsNullOrWhiteSpace(request))
@@ -228,7 +207,6 @@ namespace ArgonFetch.Application.Plugins
                 : (parts[0], null);
         }
 
-        /// <summary>Compares as a version where possible, so 1.10.0 outranks 1.9.0.</summary>
         private static Version ParseVersion(string version) =>
             Version.TryParse(version.Split('-')[0], out var parsed) ? parsed : new Version(0, 0);
     }

--- a/src/ArgonFetch.Application/Plugins/PluginLoadContext.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginLoadContext.cs
@@ -24,8 +24,6 @@ namespace ArgonFetch.Application.Plugins
         private static readonly string[] Shared =
         [
             "ArgonFetch.Abstractions",
-            // The two the contract itself exposes. A plugin handed an ILogger from its own copy
-            // of the abstractions could not be given the host's logger.
             "Microsoft.Extensions.Logging.Abstractions",
             "Microsoft.Extensions.Caching.Abstractions",
             "Microsoft.Extensions.Primitives",

--- a/src/ArgonFetch.Application/Plugins/PluginLoader.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginLoader.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 
 namespace ArgonFetch.Application.Plugins
 {
-    /// <summary>A plugin that was loaded, and what came out of it.</summary>
     public sealed record LoadedPlugin(
         string Id,
         string? Name,
@@ -26,19 +25,12 @@ namespace ArgonFetch.Application.Plugins
         internal AssemblyLoadContext? Context { get; init; }
     }
 
-    /// <summary>
-    /// Turns the plugins folder into objects the application can call.
-    /// </summary>
     public class PluginLoader
     {
         private readonly ILogger<PluginLoader> _logger;
 
         public PluginLoader(ILogger<PluginLoader> logger) => _logger = logger;
 
-        /// <summary>
-        /// Loads the requested plugins, in the order they were requested - which is the order
-        /// their providers are then asked in.
-        /// </summary>
         public IReadOnlyList<LoadedPlugin> Load(string root, IEnumerable<string> install)
         {
             var loaded = new List<LoadedPlugin>();
@@ -70,7 +62,6 @@ namespace ArgonFetch.Application.Plugins
                 }
                 catch (Exception ex)
                 {
-                    // One bad plugin costs its own sources and nothing else.
                     _logger.LogError(ex, "Could not load the {Id} plugin", parsed.Value.Id);
                 }
             }
@@ -80,9 +71,6 @@ namespace ArgonFetch.Application.Plugins
 
         private LoadedPlugin? LoadOne(string folder, string id)
         {
-            // The assembly named after the folder, or failing that whichever one declares
-            // itself a plugin. Named first because it is the cheap answer and almost always
-            // the right one.
             var candidates = Directory.GetFiles(folder, "*.dll")
                 .OrderByDescending(path => Path.GetFileNameWithoutExtension(path)
                     .EndsWith(id, StringComparison.OrdinalIgnoreCase))
@@ -99,7 +87,6 @@ namespace ArgonFetch.Application.Plugins
                 }
                 catch (BadImageFormatException)
                 {
-                    // A native library sitting beside the managed ones.
                     context.Unload();
                     continue;
                 }
@@ -114,8 +101,6 @@ namespace ArgonFetch.Application.Plugins
 
                 if (manifest.Abi != ArgonFetchPluginAttribute.CurrentAbi)
                 {
-                    // Set aside before anything in it runs. A contract that changed shape is not
-                    // something to find out about halfway through somebody's download.
                     _logger.LogWarning(
                         "The {Id} plugin was built for contract {Theirs}; this build implements {Ours}",
                         manifest.Id, manifest.Abi, ArgonFetchPluginAttribute.CurrentAbi);
@@ -156,8 +141,6 @@ namespace ArgonFetch.Application.Plugins
                 if (type.IsAbstract || type.IsInterface || !typeof(T).IsAssignableFrom(type))
                     continue;
 
-                // Parameterless only, as the manifest is read before any of the host's services
-                // could be handed over. What a plugin needs arrives with each call instead.
                 if (type.GetConstructor(Type.EmptyTypes) is null)
                 {
                     _logger.LogWarning("{Type} has no parameterless constructor and was skipped", type.FullName);

--- a/src/ArgonFetch.Application/Plugins/PluginOptions.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginOptions.cs
@@ -12,10 +12,6 @@ namespace ArgonFetch.Application.Plugins
     {
         public const string SectionName = "Plugins";
 
-        /// <summary>
-        /// Indexes to look in, in order. Each is the URL of an index.json listing what that
-        /// repository publishes.
-        /// </summary>
         public List<string> Repositories { get; set; } = [];
 
         /// <summary>
@@ -30,38 +26,21 @@ namespace ArgonFetch.Application.Plugins
         /// </summary>
         public List<string> Install { get; set; } = [];
 
-        /// <summary>
-        /// Where plugins are kept. Relative paths are from the content root.
-        /// </summary>
         public string Path { get; set; } = "plugins";
 
-        /// <summary>
-        /// Settings for individual plugins, keyed by plugin id. Reaches the plugin as its
-        /// <c>IProviderContext.Settings</c>.
-        /// </summary>
         public Dictionary<string, Dictionary<string, string?>> Settings { get; set; } = [];
     }
 
-    /// <summary>One plugin as a repository index describes it.</summary>
     public sealed record PluginIndexEntry
     {
         public string Id { get; init; } = string.Empty;
         public string? Name { get; init; }
         public string Version { get; init; } = string.Empty;
 
-        /// <summary>
-        /// Contract this was built against. The host implements exactly one and skips anything
-        /// else, because a contract that changed shape is not something to guess at.
-        /// </summary>
         public int Abi { get; init; }
 
-        /// <summary>Path to the archive, relative to the index that named it.</summary>
         public string File { get; init; } = string.Empty;
 
-        /// <summary>
-        /// Hash of that archive. Checked after downloading, which is what makes a plugin
-        /// repository something you can host anywhere without also having to trust the host.
-        /// </summary>
         public string Sha256 { get; init; } = string.Empty;
     }
 }

--- a/src/ArgonFetch.Application/Plugins/ProviderContext.cs
+++ b/src/ArgonFetch.Application/Plugins/ProviderContext.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 
 namespace ArgonFetch.Application.Plugins
 {
-    /// <summary>Makes a context for one plugin to work with.</summary>
     public interface IProviderContextFactory
     {
         IProviderContext For(string pluginId, Func<Uri, CancellationToken, Task<ProbeResult?>> probe);
@@ -74,17 +73,12 @@ namespace ArgonFetch.Application.Plugins
 
             public IReadOnlyDictionary<string, string?> Settings { get; }
 
-            // Whichever client the pool's next proxy needs, or the plain one. The same service
-            // the rest of the application fetches media through, so a plugin is subject to the
-            // same rotation rather than quietly going direct.
             public HttpClient CreateHttpClient(bool rotateProxy = true) =>
                 _httpClients.For(rotateProxy ? _proxyPool.Next() : null);
 
             public Task<ProbeResult?> ProbeAsync(Uri url, CancellationToken cancellationToken) =>
                 _probe(url, cancellationToken);
 
-            // Prefixed so two plugins caching "track:1" cannot overwrite one another - the cache
-            // is the application's, not any one plugin's.
             public string CacheKey(string key) => $"plugin:{_pluginId}:{key}";
         }
     }

--- a/src/ArgonFetch.Application/Plugins/ProviderRegistry.cs
+++ b/src/ArgonFetch.Application/Plugins/ProviderRegistry.cs
@@ -4,18 +4,12 @@ using Microsoft.Extensions.Logging;
 
 namespace ArgonFetch.Application.Plugins
 {
-    /// <summary>
-    /// Decides which provider, if any, wants a link.
-    /// </summary>
     public interface IProviderRegistry
     {
-        /// <summary>The provider that handles this link, or null to fetch it the ordinary way.</summary>
         ISourceProvider? For(Uri url);
 
-        /// <summary>Every hook, to be applied in turn before a fetch.</summary>
         IReadOnlyList<IFetchOptionsHook> Hooks { get; }
 
-        /// <summary>What is loaded, for the application information endpoint.</summary>
         IReadOnlyList<LoadedPlugin> Plugins { get; }
     }
 
@@ -55,9 +49,6 @@ namespace ArgonFetch.Application.Plugins
 
         public IReadOnlyList<LoadedPlugin> Plugins { get; }
 
-        /// <summary>
-        /// Compiles a provider's declared patterns once, here, rather than on every request.
-        /// </summary>
         private static IReadOnlyList<Regex> Compile(string pluginId, ISourceProvider provider, ILogger logger)
         {
             var compiled = new List<Regex>();
@@ -85,8 +76,6 @@ namespace ArgonFetch.Application.Plugins
                 }
                 catch (ArgumentException ex)
                 {
-                    // One unusable pattern costs that pattern. The plugin may well have others,
-                    // and taking it out entirely over a typo helps nobody.
                     logger.LogWarning(ex, "The {Id} plugin declared a pattern that does not compile: {Pattern}", pluginId, pattern);
                 }
             }
@@ -99,9 +88,6 @@ namespace ArgonFetch.Application.Plugins
 
         public ISourceProvider? For(Uri url)
         {
-            // Every provider is asked, rather than stopping at the first that says yes. A second
-            // claim on the same link is worth knowing about: left unsaid, the losing plugin
-            // simply never runs and nobody can see why.
             var address = url.ToString();
             var claimed = _providers.Where(entry => Claims(entry, url, address)).ToList();
 
@@ -123,8 +109,6 @@ namespace ArgonFetch.Application.Plugins
         {
             try
             {
-                // The declared patterns first, then the provider's own say - which almost every
-                // provider leaves at the default, because the patterns were the whole answer.
                 return entry.Patterns.Any(pattern => pattern.IsMatch(address)) && entry.Provider.CanHandle(url);
             }
             catch (RegexMatchTimeoutException)
@@ -134,9 +118,6 @@ namespace ArgonFetch.Application.Plugins
             }
             catch (Exception ex)
             {
-                // A provider that throws while deciding has answered no. It is asked on every
-                // request, including ones for sources it has nothing to do with, so a fault
-                // here must not be able to break an unrelated download.
                 _logger.LogWarning(ex, "The {Id} plugin threw while deciding about {Url}", entry.PluginId, url);
                 return false;
             }

--- a/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
@@ -1,8 +1,6 @@
 ﻿using ArgonFetch.Application.Dtos;
 using ArgonFetch.Application.Enums;
 using ArgonFetch.Application.Services;
-// Both namespaces name one: the contract has its own so a plugin need not reference the
-// application, and the application keeps the one its cache and file naming already speak.
 using MediaTags = ArgonFetch.Application.Services.MediaTags;
 using ArgonFetch.Abstractions;
 using ArgonFetch.Application.Plugins;
@@ -44,9 +42,6 @@ namespace ArgonFetch.Application.Queries
         // requested them, so it has to travel with them to the stream endpoint.
         private string? _fetchProxy;
 
-        // Set when a plugin rewrote the link. Knowing the release better than the page it was
-        // redirected to is the reason the track was matched rather than merely searched for, so
-        // what the plugin said wins over what the fetch reports.
         private MediaTags? _overrideTags;
         private string? _overrideCover;
         private string? _originalUrl;
@@ -82,8 +77,6 @@ namespace ArgonFetch.Application.Queries
         {
             var resolved = await Resolve(request, cancellationToken);
 
-            // Stamped in one place rather than at each of the half-dozen points that build
-            // a result, so a new source cannot forget it.
             resolved.RequestedUrl = request.Query;
 
             return resolved;
@@ -91,7 +84,6 @@ namespace ArgonFetch.Application.Queries
 
         private async Task<ResourceInformationDto> Resolve(GetMediaQuery request, CancellationToken cancellationToken)
         {
-            // Plugins first, and only for a real link - a search term is nobody's source.
             if (Uri.TryCreate(request.Query, UriKind.Absolute, out var link))
             {
                 var handled = await AskProvidersAsync(link, request, cancellationToken);
@@ -102,8 +94,6 @@ namespace ArgonFetch.Application.Queries
 
             var platform = PlatformIdentifierService.IdentifyPlatform(request.Query);
 
-            // Asked before fetching rather than after: a playlist read the ordinary way extracts
-            // every entry in full, which is seconds apiece and minutes for a list of any size.
             if (await IsCollection(request.Query, platform))
                 return await HandleCollection(request.Query);
 
@@ -113,7 +103,6 @@ namespace ArgonFetch.Application.Queries
             {
                 string thumbnailUrl = resultData.Thumbnail;
 
-                // Try to find largest square thumbnail if available
                 if (resultData.Thumbnails?.Any() == true)
                 {
                     var squareThumbnails = resultData.Thumbnails
@@ -129,14 +118,11 @@ namespace ArgonFetch.Application.Queries
                     }
                 }
 
-                // First, check if we have formats that already contain both video AND audio
                 var combinedFormats = ExtractCombinedFormatsAndCacheNewUrl(resultData.Formats);
 
                 StreamReferenceDto? combinedReferences = null;
                 StreamReferenceDto? audioReferences = null;
 
-                // Carried into the cache so the stream endpoint can name and tag the file it
-                // serves; by then only a key is left to identify the media by.
                 var tags = _overrideTags ?? new MediaTags(resultData.Title, resultData.Uploader);
 
                 var audioRenditions = _proxyUrlBuilder.BuildRenditions(
@@ -151,9 +137,6 @@ namespace ArgonFetch.Application.Queries
 
                 if (HasValidUrls(combinedFormats))
                 {
-                    // Pre-muxed formats are served as they are, so they are renditions of the
-                    // pass-through kind rather than something to combine - which is also the
-                    // fast path, since nothing has to be run through FFmpeg.
                     videoUrlType = UrlType.Media;
                     videoRenditions = _proxyUrlBuilder.BuildRenditions(
                         RenditionPicker.PickVideo(PreMuxedSources(resultData.Formats), perContainer: true),
@@ -164,8 +147,6 @@ namespace ArgonFetch.Application.Queries
                 }
                 else
                 {
-                    // Nothing carries both tracks, so each video step is paired with the best
-                    // audio and muxed on the way out.
                     videoUrlType = UrlType.Combined;
                     videoRenditions = _combinedUrlBuilder.BuildCombinedRenditions(
                         RenditionPicker.PickVideo(VideoOnlySources(resultData.Formats)),
@@ -175,9 +156,6 @@ namespace ArgonFetch.Application.Queries
                         tags);
                 }
 
-                // Left null rather than empty when a source has none of that kind: an audio-only
-                // track that still reported a video reference put an empty Video menu in front of
-                // people, offering a choice with nothing behind it.
                 combinedReferences = videoRenditions.Count > 0
                     ? new StreamReferenceDto { UrlType = videoUrlType, Renditions = videoRenditions }
                     : null;
@@ -207,13 +185,6 @@ namespace ArgonFetch.Application.Queries
                 throw new NotSupportedException("This isn't implemented yet");
         }
 
-        /// <summary>
-        /// Offers the link to whichever plugin claims it, and turns its answer into a result.
-        /// <para>
-        /// Null when no plugin wanted it, or when the one that did decided there was nothing to
-        /// do - both of which mean carrying on and fetching the link the ordinary way.
-        /// </para>
-        /// </summary>
         private async Task<ResourceInformationDto?> AskProvidersAsync(
             Uri link,
             GetMediaQuery request,
@@ -234,8 +205,6 @@ namespace ArgonFetch.Application.Queries
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                // A plugin that fails is not a reason to refuse the link outright: yt-dlp knows
-                // a great many sources, and the ordinary path may well handle it.
                 _logger.LogWarning(ex, "The {Id} plugin failed on {Url}; falling back", provider.Id, link);
                 return null;
             }
@@ -243,8 +212,6 @@ namespace ArgonFetch.Application.Queries
             switch (outcome)
             {
                 case ProviderOutcome.RewriteOutcome rewrite:
-                    // The fetch that follows is the ordinary one; it is only pointed elsewhere,
-                    // and told what to call what it finds.
                     _logger.LogInformation("The {Id} plugin redirected {From} to {To}", provider.Id, link, rewrite.Url);
 
                     _overrideTags = new MediaTags(rewrite.Tags.Title, rewrite.Tags.Artist);
@@ -265,10 +232,6 @@ namespace ArgonFetch.Application.Queries
             }
         }
 
-        /// <summary>
-        /// A plugin's listing, as the API describes one. Entries stay unresolved, exactly as they
-        /// do for a collection yt-dlp listed.
-        /// </summary>
         private ResourceInformationDto MapCollection(CollectionResult collection, string pluginId)
         {
             if (collection.MayBeTruncated)
@@ -298,11 +261,6 @@ namespace ArgonFetch.Application.Queries
             };
         }
 
-        /// <summary>
-        /// Media a plugin fetched itself. It hands over plain addresses; caching them, hiding
-        /// them behind keys and building the URLs a client is given stay here, because that is
-        /// how this application serves bytes and it is not a plugin's business.
-        /// </summary>
         private ResourceInformationDto MapMedia(MediaResult media, string requestedUrl)
         {
             var tags = new MediaTags(media.Title, media.Author);
@@ -354,10 +312,6 @@ namespace ArgonFetch.Application.Queries
                 : new StreamReferenceDto { UrlType = UrlType.Media, Renditions = renditions };
         }
 
-        /// <summary>
-        /// What the fetch engine can say about a link without downloading it, for a plugin
-        /// choosing between candidates.
-        /// </summary>
         private async Task<ProbeResult?> ProbeAsync(Uri url, CancellationToken cancellationToken)
         {
             try
@@ -368,18 +322,11 @@ namespace ArgonFetch.Application.Queries
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                // A link that cannot be read is an answer, not a fault - it is exactly what a
-                // plugin sifting candidates wants to know.
                 _logger.LogDebug(ex, "Could not probe {Url}", url);
                 return null;
             }
         }
 
-        /// <summary>
-        /// Whether the link names a collection rather than one recording. A source that has no
-        /// notion of playlists, or a link that is simply not one, answers no rather than failing:
-        /// an unreadable link is the fetch's problem to report, not this one's.
-        /// </summary>
         private static async Task<bool> IsCollection(string query, Platform platform)
         {
             try
@@ -392,16 +339,6 @@ namespace ArgonFetch.Application.Queries
             }
         }
 
-        /// <summary>
-        /// A playlist from any source yt-dlp can read - a YouTube list, a SoundCloud set.
-        /// <para>
-        /// Listed flat, so each entry costs a line of the index rather than its own extraction.
-        /// The entries are deliberately left unresolved for the same reason the Spotify listing
-        /// leaves them: resolving several hundred before showing anything would take minutes and
-        /// throw nearly all of it away. Picking one fetches that entry through the path its own
-        /// link already takes.
-        /// </para>
-        /// </summary>
         private async Task<ResourceInformationDto> HandleCollection(string query)
         {
             var listing = await YT_DLP_Fetch(query, new OptionSet
@@ -421,32 +358,18 @@ namespace ArgonFetch.Application.Queries
                 Author = listing.Uploader ?? listing.Channel,
                 CoverUrl = LargestThumbnail(listing),
                 MediaItems = entries
-                    // A flat listing still carries rows for entries that have been deleted or made
-                    // private, and those have no link to fetch anything by.
                     .Where(entry => !string.IsNullOrWhiteSpace(entry.Url) || !string.IsNullOrWhiteSpace(entry.WebpageUrl))
                     .Select(entry => new MediaInformationDto
                     {
                         RequestedUrl = entry.WebpageUrl ?? entry.Url,
                         Title = entry.Title ?? NameFromUrl(entry.WebpageUrl ?? entry.Url) ?? "Unknown",
                         Author = entry.Uploader ?? entry.Channel ?? listing.Uploader ?? string.Empty,
-                        // Falls back to the list's own picture, which is what a source that
-                        // reports no per-entry artwork leaves us with.
                         CoverUrl = LargestThumbnail(entry) ?? LargestThumbnail(listing),
                     })
                     .ToList()
             };
         }
 
-        /// <summary>
-        /// A readable name recovered from a link's last segment, for a listing that names nothing.
-        /// <para>
-        /// SoundCloud sets are listed as bare links - no title, no credit, no artwork - and every
-        /// row otherwise reads "Unknown", which is unusable for picking a track. The slug is a
-        /// close enough rendering of the name to choose by, and the real title arrives once the
-        /// entry is opened. Naming every row after its own link is worth more than being tidy
-        /// about the apostrophe that a slug has lost.
-        /// </para>
-        /// </summary>
         internal static string? NameFromUrl(string? url)
         {
             if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
@@ -468,9 +391,6 @@ namespace ArgonFetch.Application.Queries
             return string.IsNullOrWhiteSpace(name) ? null : name;
         }
 
-        /// <summary>
-        /// The biggest picture a result carries, or null when it carries none.
-        /// </summary>
         private static string? LargestThumbnail(VideoData data)
         {
             var largest = data.Thumbnails?
@@ -483,7 +403,6 @@ namespace ArgonFetch.Application.Queries
 
         private StreamingUrlDto ExtractCombinedFormatsAndCacheNewUrl(FormatData[] formatData)
         {
-            // Get formats that already have both video AND audio (no muxing needed!)
             var combinedFormats = formatData
                 .Where(f =>
                     !string.IsNullOrEmpty(f.VideoCodec) &&
@@ -532,9 +451,6 @@ namespace ArgonFetch.Application.Queries
                     !string.IsNullOrEmpty(urls.WorstQuality));
         }
 
-        /// <summary>
-        /// Formats that already carry both tracks, so they can be served untouched.
-        /// </summary>
         private static IEnumerable<RenditionSource> PreMuxedSources(FormatData[] formatData) =>
             formatData
                 .Where(f =>
@@ -545,7 +461,6 @@ namespace ArgonFetch.Application.Queries
                     !f.Protocol.Contains("m3u8"))
                 .Select(ToSource);
 
-        /// <summary>Video tracks without audio, which have to be muxed before use.</summary>
         private static IEnumerable<RenditionSource> VideoOnlySources(FormatData[] formatData) =>
             formatData
                 .Where(f =>
@@ -565,8 +480,6 @@ namespace ArgonFetch.Application.Queries
                     !f.Protocol.Contains("mhtml") &&
                     !f.Protocol.Contains("m3u8") &&
                     f.AudioBitrate is > 0)
-                // Weighted the same way the three fixed rungs are, so the top rendition and
-                // "best" do not disagree about which format wins.
                 .OrderByDescending(f => f.Bitrate * OpusQualityFactor(f.AudioCodec))
                 .Select(ToSource);
 
@@ -578,16 +491,8 @@ namespace ArgonFetch.Application.Queries
             format.Bitrate,
             (long?)(format.FileSize ?? format.ApproximateFileSize));
 
-        /// <summary>
-        /// The watch page for a song id, which is what yt-dlp is given to fetch.
-        /// </summary>
         private static string WatchUrl(string id) => $"https://music.youtube.com/watch?v={id}";
 
-        /// <summary>
-        /// Opus is worth roughly 20% more than AAC at the same bitrate, so it is weighted that
-        /// way rather than compared on the raw number. YouTube offers the two within a kbps of
-        /// each other, which would otherwise make the pick a coin toss.
-        /// </summary>
         private static double OpusQualityFactor(string? audioCodec) =>
             audioCodec?.StartsWith("opus", StringComparison.OrdinalIgnoreCase) == true ? 1.2 : 1.0;
 
@@ -595,8 +500,6 @@ namespace ArgonFetch.Application.Queries
         {
             options ??= new OptionSet { DumpSingleJson = true };
 
-            // Not only for Instagram: an age-gated YouTube video needs a session too, and a
-            // source that does not care simply ignores them.
             options.Cookies = _toolPaths.CookiesPath;
 
             if (!Uri.IsWellFormedUriString(query, UriKind.Absolute))
@@ -614,8 +517,6 @@ namespace ArgonFetch.Application.Queries
                 query = searchResult.Data.Entries.First().Url;
             }
 
-            // A failed fetch is retried through the next proxy, since the usual cause is the
-            // current one being blocked. Capped at 3 so a dead list still fails quickly.
             var attempts = Math.Min(Math.Max(_proxyPool.Count, 1), 3);
             RunResult<VideoData> result;
 
@@ -631,13 +532,9 @@ namespace ArgonFetch.Application.Queries
             {
                 var errors = string.Join(", ", result.ErrorOutput);
 
-                // Separated from a plain failure because the two mean different things to
-                // whoever pasted the link: DRM is a refusal, not a bad address.
                 if (YtDlpErrors.IsDrmProtected(result.ErrorOutput))
                     throw new NotSupportedException("This media is DRM protected and cannot be downloaded.");
 
-                // Told apart from a missing page for the same reason as DRM: the link is right
-                // and the fix is a cookies file, which the reader can actually act on.
                 if (YtDlpErrors.NeedsSignedInSession(result.ErrorOutput))
                     throw new NotSupportedException(
                         _toolPaths.CookiesPath is null

--- a/src/ArgonFetch.Application/Queries/StreamArchiveQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamArchiveQuery.cs
@@ -10,9 +10,6 @@ using Microsoft.Extensions.Logging;
 
 namespace ArgonFetch.Application.Queries
 {
-    /// <summary>
-    /// Every track of a collection, as one zip.
-    /// </summary>
     public class StreamArchiveQuery : IRequest<StreamResult>
     {
         public StreamArchiveQuery(string url, string? jobId, HttpResponse response, CancellationToken cancellationToken)
@@ -25,41 +22,15 @@ namespace ArgonFetch.Application.Queries
 
         public string Url { get; }
 
-        /// <summary>
-        /// Where to publish progress, chosen by the caller. Null when nobody is watching, which
-        /// is what a plain curl of this endpoint looks like.
-        /// </summary>
         public string? JobId { get; }
         public HttpResponse Response { get; }
         public CancellationToken CancellationToken { get; }
     }
 
-    /// <summary>
-    /// Builds the zip while sending it.
-    /// <para>
-    /// Nothing is assembled on disk first: a hundred tracks is a few hundred megabytes, and
-    /// holding that per request is how a downloader falls over when two people use it at once.
-    /// The archive is written straight onto the response as each track arrives, which also means
-    /// the transfer starts within seconds rather than after every track has been fetched.
-    /// </para>
-    /// </summary>
     public class StreamArchiveQueryHandler : IRequestHandler<StreamArchiveQuery, StreamResult>
     {
-        /// <summary>
-        /// How many tracks one archive may carry.
-        /// <para>
-        /// A playlist can hold thousands, and fetching those means thousands of extractions and
-        /// tens of gigabytes down a single request that any proxy in the way will cut long before
-        /// the end. What is left out is written into the archive rather than passed over quietly.
-        /// </para>
-        /// </summary>
         internal const int MaxTracks = 100;
 
-        /// <summary>
-        /// How many tracks are worked out at once. Each costs an extraction of a few seconds, so
-        /// doing them one after another makes a large archive start very slowly; doing all of
-        /// them at once is a burst of traffic that gets a source's attention.
-        /// </summary>
         private const int ResolveConcurrency = 4;
 
         private readonly IMediator _mediator;
@@ -119,8 +90,6 @@ namespace ArgonFetch.Application.Queries
             request.Response.Headers.ContentDisposition =
                 MediaFileName.ContentDisposition(new MediaTags(listing.Title, listing.Author), ".zip", "playlist");
 
-            // Built as it is sent, so its length is not knowable in advance and the client shows
-            // an indeterminate transfer. Declaring one would mean building the whole thing first.
             request.Response.Headers.Append("Cache-Control", "no-store");
 
             _logger.LogInformation(
@@ -141,9 +110,6 @@ namespace ArgonFetch.Application.Queries
                 await using var archive = await ZipArchive.CreateAsync(
                     request.Response.Body, ZipArchiveMode.Create, leaveOpen: true, entryNameEncoding: null);
 
-                // Resolution runs ahead of writing, bounded, so a track is usually ready by the
-                // time its turn comes. The bytes are not fetched here - only the address of them -
-                // so running ahead costs no memory.
                 using var gate = new SemaphoreSlim(ResolveConcurrency);
 
                 var resolving = wanted
@@ -165,12 +131,8 @@ namespace ArgonFetch.Application.Queries
                         continue;
                     }
 
-                    // Two tracks on one release can share a name, and a zip with two identical
-                    // entries unpacks to one file.
                     var name = Unique(track.FileName, used);
 
-                    // Stored rather than deflated: these are already compressed formats, so
-                    // compressing them again spends processor time to save nothing.
                     var slot = archive.CreateEntry(name, CompressionLevel.NoCompression);
 
                     await using var slotStream = await slot.OpenAsync(cancellationToken);
@@ -187,8 +149,6 @@ namespace ArgonFetch.Application.Queries
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
-                        // The entry is already open and partly written by now, so it stays in the
-                        // archive; the manifest is what tells the reader it is short.
                         _logger.LogWarning(ex, "Could not write {Name} into the archive", name);
                         failures.Add(wanted[index].Title);
                     }
@@ -211,8 +171,6 @@ namespace ArgonFetch.Application.Queries
             }
             catch (Exception ex)
             {
-                // Anything thrown once the first byte is out cannot be turned into a status code,
-                // so the archive simply ends early and the client sees a truncated download.
                 _logger.LogError(ex, "Failed while writing the archive for {Url}", request.Url);
 
                 if (jobId is not null)
@@ -229,10 +187,6 @@ namespace ArgonFetch.Application.Queries
             return StreamResult.Success();
         }
 
-        /// <summary>
-        /// Marks a job failed that never got as far as having a track count, so a page watching
-        /// it is told rather than left waiting on something that will never report.
-        /// </summary>
         private void FailBeforeStarting(string? jobId)
         {
             if (jobId is null)
@@ -242,11 +196,6 @@ namespace ArgonFetch.Application.Queries
             _progress.Finish(jobId, ArchiveProgress.Failed);
         }
 
-        /// <summary>
-        /// One entry's best audio, or null when it could not be resolved. A playlist entry
-        /// carries only a link - the same link a row's own download button follows - so this is
-        /// the same fetch, taken one at a time under the gate.
-        /// </summary>
         private async Task<ResolvedTrack?> ResolveAsync(
             MediaInformationDto entry,
             SemaphoreSlim gate,
@@ -279,8 +228,6 @@ namespace ArgonFetch.Application.Queries
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                // A track with no counterpart to download from is normal on a long playlist, and
-                // is not a reason to abandon the other ninety-nine.
                 _logger.LogInformation(ex, "Leaving {Title} out of the archive", entry.Title);
                 return null;
             }
@@ -290,10 +237,6 @@ namespace ArgonFetch.Application.Queries
             }
         }
 
-        /// <summary>
-        /// A note inside the archive saying what is not in it. Written only when something is
-        /// missing, so a complete archive holds nothing but the music.
-        /// </summary>
         private static async Task WriteManifestAsync(
             ZipArchive archive,
             ResourceInformationDto listing,
@@ -334,9 +277,6 @@ namespace ArgonFetch.Application.Queries
             await writer.WriteAsync(note.ToString());
         }
 
-        /// <summary>
-        /// The name with a counter appended if that name is already in the archive.
-        /// </summary>
         internal static string Unique(string name, HashSet<string> used)
         {
             if (used.Add(name))

--- a/src/ArgonFetch.Application/Queries/StreamCombinedMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamCombinedMediaQuery.cs
@@ -40,13 +40,11 @@ namespace ArgonFetch.Application.Queries
         {
             try
             {
-                // Validate input
                 if (string.IsNullOrWhiteSpace(request.Key))
                 {
                     return StreamResult.BadRequest("Cache key is required");
                 }
 
-                // Get URLs from cache
                 var (actualVideoUrl, actualAudioUrl, proxy, tags) = _cacheService.GetCachedUrls(request.Key);
 
                 if (actualVideoUrl == null || actualAudioUrl == null)
@@ -54,12 +52,10 @@ namespace ArgonFetch.Application.Queries
                     return StreamResult.NotFound("Cache key expired or not found");
                 }
 
-                // Set response headers before starting stream
                 request.Response.ContentType = "video/mp4";
                 request.Response.Headers.ContentDisposition = MediaFileName.ContentDisposition(tags, ".mp4");
                 request.Response.Headers.Append("Cache-Control", "no-cache");
 
-                // Start streaming - once this starts, we cannot change headers
                 await _ffmpegStreamingService.StreamCombinedMediaAsync(
                     actualVideoUrl,
                     actualAudioUrl,
@@ -72,7 +68,6 @@ namespace ArgonFetch.Application.Queries
             }
             catch (OperationCanceledException)
             {
-                // Client disconnected, this is normal
                 _logger.LogInformation("Client disconnected during streaming");
                 return StreamResult.ClientDisconnected();
             }

--- a/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
@@ -23,16 +23,8 @@ namespace ArgonFetch.Application.Queries
             RangeHeader = rangeHeader;
         }
 
-        /// <summary>
-        /// The caller's Range header, if it sent one. Honoured only where bytes are passed
-        /// through: a conversion has no fixed length to seek within.
-        /// </summary>
         public string? RangeHeader { get; }
 
-        /// <summary>
-        /// Container the caller insists on, currently only "mp3". Null serves the source
-        /// untouched, which is faster and keeps the original quality.
-        /// </summary>
         public string? Format { get; }
 
         public string Key { get; }
@@ -63,13 +55,11 @@ namespace ArgonFetch.Application.Queries
         {
             try
             {
-                // Validate input
                 if (string.IsNullOrWhiteSpace(request.Key))
                 {
                     return StreamResult.BadRequest("Cache key is required");
                 }
 
-                // Get URL and format info from cache
                 var cacheData = _cacheService.GetCachedUrlWithFormat(request.Key);
 
                 if (cacheData == null)
@@ -79,13 +69,8 @@ namespace ArgonFetch.Application.Queries
 
                 var (mediaUrl, isAudio, advertisedMimeType, proxy, tags) = cacheData.Value;
 
-                // The fetch response already committed to a media type for this key. When it
-                // knows one, those bytes go out untouched: re-encoding Opus into MP3 cost a
-                // generation of quality, every tag the source carried, and the FFmpeg pass.
                 var passThroughMimeType = advertisedMimeType ?? StandardFormatMimeType(mediaUrl, isAudio);
 
-                // A caller can still ask for MP3 explicitly - players that cannot read Opus are
-                // the reason the endpoint used to convert everything - but it is opt-in now.
                 var mp3Requested = string.Equals(request.Format, "mp3", StringComparison.OrdinalIgnoreCase);
                 bool needsConversion = passThroughMimeType == null || (isAudio && mp3Requested);
 
@@ -94,15 +79,11 @@ namespace ArgonFetch.Application.Queries
                     _logger.LogInformation("Converting media from {Url} to {Format}",
                         mediaUrl, isAudio ? "MP3" : "MP4");
 
-                    // Set response headers for converted format
                     request.Response.ContentType = isAudio ? "audio/mpeg" : "video/mp4";
                     request.Response.Headers.Append("Cache-Control", "public, max-age=3600");
                     request.Response.Headers.ContentDisposition =
                         MediaFileName.ContentDisposition(tags, isAudio ? ".mp3" : ".mp4");
 
-                    // Stream and convert using FFmpeg. The conversion re-encodes anyway, so it
-                    // is the one path that can write the title, artist and cover art into the
-                    // file rather than only into its name.
                     await _ffmpegStreamingService.ConvertAndStreamMediaAsync(
                         mediaUrl,
                         request.Response.Body,
@@ -113,18 +94,13 @@ namespace ArgonFetch.Application.Queries
                 }
                 else
                 {
-                    // Source format, stream directly without conversion
                     _logger.LogInformation("Streaming {MimeType} media from {Url} using accelerated download via {Proxy}",
                         passThroughMimeType, mediaUrl, MediaHttpClients.Describe(proxy));
 
                     request.Response.ContentType = passThroughMimeType;
 
-                    // Add cache headers
                     request.Response.Headers.Append("Cache-Control", "public, max-age=3600");
 
-                    // Named, but not touched: writing tags into these bytes would mean remuxing
-                    // them, which costs the exact length the response has already promised and
-                    // the byte ranges a client may be asking for.
                     request.Response.Headers.ContentDisposition = MediaFileName.ContentDisposition(
                         tags,
                         MediaFormats.ExtensionFor(passThroughMimeType) ?? (isAudio ? ".mp3" : ".mp4"));
@@ -147,9 +123,6 @@ namespace ArgonFetch.Application.Queries
                     {
                         var total = upstreamLength.Value;
 
-                        // Advertised only here, where it is true: the bytes come from a source
-                        // that serves ranges and reach the caller untouched, so a seek can be
-                        // answered exactly.
                         request.Response.Headers.AcceptRanges = "bytes";
 
                         switch (Services.RangeHeader.Parse(request.RangeHeader, total, out var requested))
@@ -184,9 +157,6 @@ namespace ArgonFetch.Application.Queries
                         _logger.LogInformation("Upstream did not report a length for {Url}; response will be chunked", mediaUrl);
                     }
 
-                    // The service already falls back to a single connection internally, and only
-                    // while doing so is still safe. Retrying here would append a second copy of
-                    // the file to a response body that may already hold part of one.
                     await _acceleratedDownloadService.StreamWithAccelerationAsync(
                         mediaUrl,
                         request.Response.Body,
@@ -200,7 +170,6 @@ namespace ArgonFetch.Application.Queries
             }
             catch (OperationCanceledException)
             {
-                // Client disconnected, this is normal
                 _logger.LogInformation("Client disconnected during media streaming");
                 return StreamResult.ClientDisconnected();
             }
@@ -221,21 +190,12 @@ namespace ArgonFetch.Application.Queries
             }
         }
 
-        /// <summary>
-        /// The media type to serve a source with untouched, or null when it has to be converted.
-        /// <para>
-        /// Only reached for keys cached before the fetch response started recording the type,
-        /// so it works the type out of the URL: media URLs carry a "mime" query parameter, and
-        /// failing that an extension is sometimes recoverable from the path.
-        /// </para>
-        /// </summary>
         private string? StandardFormatMimeType(string url, bool isAudio)
         {
             var mimeType = GetMimeType(url);
 
             if (mimeType != null)
             {
-                // "audio/webm; codecs=opus" and friends: the parameters are not ours to forward.
                 var bare = mimeType.Split(';')[0].Trim();
 
                 if (bare.StartsWith(isAudio ? "audio/" : "video/", StringComparison.OrdinalIgnoreCase))
@@ -245,10 +205,6 @@ namespace ArgonFetch.Application.Queries
             return MediaFormats.MimeTypeFor(GetFileExtension(url), isAudio);
         }
 
-        /// <summary>
-        /// The source's media type. Media URLs carry it as a "mime" query parameter
-        /// (e.g. mime=video%2Fmp4) even though the path has no file extension.
-        /// </summary>
         private string? GetMimeType(string url)
         {
             try
@@ -280,10 +236,8 @@ namespace ArgonFetch.Application.Queries
                 var path = uri.AbsolutePath;
                 var extension = Path.GetExtension(path);
 
-                // If no extension found in path, try to extract from query parameters
                 if (string.IsNullOrEmpty(extension))
                 {
-                    // Check for common patterns like "format=mp4" or "ext=mp3"
                     var query = uri.Query.ToLower();
                     if (query.Contains("format=mp4") || query.Contains("ext=mp4"))
                         return ".mp4";

--- a/src/ArgonFetch.Application/Services/ArchiveProgress.cs
+++ b/src/ArgonFetch.Application/Services/ArchiveProgress.cs
@@ -3,12 +3,6 @@ using System.Text.Json.Serialization;
 
 namespace ArgonFetch.Application.Services
 {
-    /// <summary>How far along an archive is.</summary>
-    /// <param name="State">"building", "done" or "failed".</param>
-    /// <param name="Total">Tracks the archive will carry.</param>
-    /// <param name="Completed">Tracks written so far.</param>
-    /// <param name="Current">Title being worked on, or null once there is nothing left.</param>
-    /// <param name="Skipped">Tracks that could not be fetched and were left out.</param>
     public record ArchiveProgress(
         string State,
         int Total,
@@ -20,21 +14,10 @@ namespace ArgonFetch.Application.Services
         public const string Done = "done";
         public const string Failed = "failed";
 
-        // Read by the handler, not by the reader: State already says this, and sending both
-        // invites a client to trust the wrong one.
         [JsonIgnore]
         public bool IsFinished => State is Done or Failed;
     }
 
-    /// <summary>
-    /// Where an archive reports how it is getting on, so the page that asked for one can show it.
-    /// <para>
-    /// The archive itself is fetched as a plain link, which is what lets the browser own the
-    /// transfer and keep it after the page is left. That also means the page cannot see the
-    /// download at all, so the progress is published here against the job id the page passed in,
-    /// and read back over a separate request.
-    /// </para>
-    /// </summary>
     public interface IArchiveProgressTracker
     {
         void Start(string jobId, int total);
@@ -43,23 +26,10 @@ namespace ArgonFetch.Application.Services
         ArchiveProgress? Get(string jobId);
     }
 
-    /// <summary>
-    /// Progress held in memory, for as long as anyone could still be watching it.
-    /// <para>
-    /// Not durable on purpose: it describes a transfer that is itself only alive as long as the
-    /// request is, so outliving the process would tell a reader nothing true. One process only -
-    /// behind more than one replica the page could ask the instance that is not building its
-    /// archive, and would be told the job is unknown.
-    /// </para>
-    /// </summary>
     public class ArchiveProgressTracker : IArchiveProgressTracker
     {
-        // Long enough to cover a slow archive plus a reader that reconnects, short enough that
-        // abandoned jobs do not accumulate.
         private static readonly TimeSpan Retention = TimeSpan.FromMinutes(30);
 
-        // Kept briefly after the end so a reader that polls just after the last write still
-        // learns how it finished rather than finding nothing and guessing.
         private static readonly TimeSpan RetentionAfterFinish = TimeSpan.FromMinutes(2);
 
         private readonly IMemoryCache _cache;

--- a/src/ArgonFetch.Application/Services/ByteRange.cs
+++ b/src/ArgonFetch.Application/Services/ByteRange.cs
@@ -1,21 +1,17 @@
 namespace ArgonFetch.Application.Services
 {
-    /// <summary>A resolved byte range, inclusive at both ends as HTTP defines it.</summary>
     public readonly record struct ByteRange(long From, long To)
     {
         public long Length => To - From + 1;
     }
 
-    /// <summary>What a Range header asked for, once weighed against the resource's length.</summary>
     public enum RangeRequest
     {
-        /// <summary>No range asked for, or one this server does not honour. Serve the whole thing.</summary>
         None,
 
         /// <summary>A range that can be served: reply 206 with the resolved window.</summary>
         Satisfiable,
 
-        /// <summary>A range that starts past the end of the resource: reply 416.</summary>
         Unsatisfiable
     }
 
@@ -38,9 +34,6 @@ namespace ArgonFetch.Application.Services
 
             const string unitPrefix = "bytes=";
 
-            // Surrounding whitespace is the transport's, not the client's. Anything else out
-            // of shape - including a space around the "=" - is left unhonoured rather than
-            // guessed at.
             var value = header.Trim();
 
             if (!value.StartsWith(unitPrefix, StringComparison.OrdinalIgnoreCase))
@@ -48,7 +41,6 @@ namespace ArgonFetch.Application.Services
 
             var spec = value[unitPrefix.Length..].Trim();
 
-            // More than one range asked for; serving the first would be a lie by omission.
             if (spec.Contains(','))
                 return RangeRequest.None;
 
@@ -60,7 +52,6 @@ namespace ArgonFetch.Application.Services
             var fromText = spec[..separator].Trim();
             var toText = spec[(separator + 1)..].Trim();
 
-            // "bytes=-500" asks for the last 500 bytes rather than a range starting at zero.
             if (fromText.Length == 0)
             {
                 if (!long.TryParse(toText, out var suffixLength) || suffixLength <= 0)
@@ -78,7 +69,6 @@ namespace ArgonFetch.Application.Services
             if (from >= totalLength)
                 return RangeRequest.Unsatisfiable;
 
-            // "bytes=500-" runs to the end.
             if (toText.Length == 0)
             {
                 range = new ByteRange(from, totalLength - 1);
@@ -89,8 +79,6 @@ namespace ArgonFetch.Application.Services
             if (!long.TryParse(toText, out var to) || to < from)
                 return RangeRequest.None;
 
-            // An end past the resource is clamped rather than refused, which is what the
-            // specification asks for and what every client expects.
             range = new ByteRange(from, Math.Min(to, totalLength - 1));
 
             return RangeRequest.Satisfiable;

--- a/src/ArgonFetch.Application/Services/CombinedStreamUrlBuilder.cs
+++ b/src/ArgonFetch.Application/Services/CombinedStreamUrlBuilder.cs
@@ -6,9 +6,6 @@ namespace ArgonFetch.Application.Services
 {
     public interface ICombinedStreamUrlBuilder
     {
-        /// <summary>
-        /// Pairs each video rendition with the given audio track for muxing, best first.
-        /// </summary>
         List<MediaRenditionDto> BuildCombinedRenditions(
             IEnumerable<RenditionSource> videoSources,
             RenditionSource? audioSource,
@@ -41,8 +38,6 @@ namespace ArgonFetch.Application.Services
                     FileExtension = ".mp4",
                     MimeType = "video/mp4",
                     UrlType = UrlType.Combined,
-                    // Only reported when both halves report one: a partial sum would read as a
-                    // small download and be wrong by however much the other track weighs.
                     FileSizeBytes = video.FileSizeBytes.HasValue && audioSource.FileSizeBytes.HasValue
                         ? video.FileSizeBytes + audioSource.FileSizeBytes
                         : null,

--- a/src/ArgonFetch.Application/Services/MaintenanceState.cs
+++ b/src/ArgonFetch.Application/Services/MaintenanceState.cs
@@ -2,24 +2,11 @@ namespace ArgonFetch.Application.Services
 {
     public interface IMaintenanceState
     {
-        /// <summary>
-        /// What the app is busy with, or null when it is serving normally. Clients show this
-        /// verbatim, so it is written for a reader rather than a log.
-        /// </summary>
         string? Activity { get; }
 
-        /// <summary>
-        /// Marks the app as under maintenance until the returned handle is disposed.
-        /// </summary>
         IDisposable Begin(string activity);
     }
 
-    /// <summary>
-    /// Tracks background work that makes fetching unreliable while it runs - swapping the yt-dlp
-    /// binary being the one that actually happens. Without it a fetch landing mid-update fails
-    /// with whatever error the half-replaced binary produces, which reads like a broken site
-    /// rather than a busy server.
-    /// </summary>
     public class MaintenanceState : IMaintenanceState
     {
         private readonly Lock _gate = new();

--- a/src/ArgonFetch.Application/Services/MediaContentIdentifierService.cs
+++ b/src/ArgonFetch.Application/Services/MediaContentIdentifierService.cs
@@ -17,10 +17,6 @@ namespace ArgonFetch.Application.Services
                     var url_parms = System.Web.HttpUtility.ParseQueryString(uri.Query);
                     string? listId = url_parms.Get("list"); // null when the url carries no list
 
-                    // A watch link that also names a list is one video seen in the context of
-                    // that list, which is what YouTube plays and what yt-dlp fetches. Reading it
-                    // as the whole list would hand back several hundred entries to someone who
-                    // asked for one video.
                     if (!string.IsNullOrEmpty(listId) && string.IsNullOrEmpty(url_parms.Get("v")))
                         return listId.StartsWith("RD") ? ContentType.YouTubeRadio : ContentType.Playlist;
 
@@ -32,17 +28,6 @@ namespace ArgonFetch.Application.Services
 
                 case Platform.Unknown:
                     return ContentType.Unknown;
-                //using (var httpClient = new HttpClient())
-                //{
-                //    var response = await httpClient.GetAsync(query);
-                //    response.EnsureSuccessStatusCode();
-
-                //    var contentType = response.Content.Headers.ContentType?.MediaType;
-
-                //    return (contentType != null && (contentType.Contains("audio") || contentType.Contains("video")))
-                //        ? ContentType.Media
-                //        : ContentType.Url;
-                //}
 
                 default:
                     throw new UnknownContentTypeException();

--- a/src/ArgonFetch.Application/Services/MediaFormats.cs
+++ b/src/ArgonFetch.Application/Services/MediaFormats.cs
@@ -1,16 +1,7 @@
 ﻿namespace ArgonFetch.Application.Services
 {
-    /// <summary>
-    /// Maps a source container to the media type it is served with. Clients pick the on-disk
-    /// name and the tagging path from the mime type, so it has to describe the bytes that are
-    /// actually sent rather than the format the API would like them to be in.
-    /// </summary>
     public static class MediaFormats
     {
-        /// <summary>
-        /// Bitrate the MP3 conversion encodes at, in kbps. Shared so the offer a client shows
-        /// and the encode FFmpeg performs cannot disagree.
-        /// </summary>
         public const int Mp3BitrateKbps = 192;
 
         private static readonly Dictionary<string, string> MimeTypesByExtension =
@@ -29,13 +20,6 @@
                 [".mov"] = "video/quicktime",
             };
 
-        /// <summary>
-        /// The media type for a file extension, or null when the container is unknown and the
-        /// caller therefore has to convert rather than pass the bytes through.
-        /// <para>
-        /// WebM carries either audio or video, so the caller says which one it asked for.
-        /// </para>
-        /// </summary>
         public static string? MimeTypeFor(string? fileExtension, bool isAudio)
         {
             if (string.IsNullOrWhiteSpace(fileExtension))
@@ -52,10 +36,6 @@
             return MimeTypesByExtension.TryGetValue(extension, out var mimeType) ? mimeType : null;
         }
 
-        /// <summary>
-        /// The extension a media type is normally saved with, or null for one we do not know.
-        /// Used to name a pass-through download, whose bytes are the source's own.
-        /// </summary>
         public static string? ExtensionFor(string? mimeType)
         {
             if (string.IsNullOrWhiteSpace(mimeType))
@@ -76,7 +56,6 @@
             return null;
         }
 
-        /// <summary>Normalises an extension to a leading dot, e.g. <c>webm</c> to <c>.webm</c>.</summary>
         public static string? NormalizeExtension(string? fileExtension)
         {
             if (string.IsNullOrWhiteSpace(fileExtension))

--- a/src/ArgonFetch.Application/Services/MediaHttpClientDefaults.cs
+++ b/src/ArgonFetch.Application/Services/MediaHttpClientDefaults.cs
@@ -1,15 +1,7 @@
 namespace ArgonFetch.Application.Services
 {
-    /// <summary>
-    /// Shared configuration for the HTTP client used to fetch media from upstream CDNs.
-    /// The User-Agent is what keeps YouTube from returning 403, so it lives in one place
-    /// rather than being repeated at every call site.
-    /// </summary>
     public static class MediaHttpClientDefaults
     {
-        /// <summary>
-        /// Name of the client registered with IHttpClientFactory.
-        /// </summary>
         public const string ClientName = "media";
 
         public const string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";

--- a/src/ArgonFetch.Application/Services/MediaHttpClients.cs
+++ b/src/ArgonFetch.Application/Services/MediaHttpClients.cs
@@ -5,10 +5,6 @@ namespace ArgonFetch.Application.Services
 {
     public interface IMediaHttpClients
     {
-        /// <summary>
-        /// Client for fetching a media URL. Pass the proxy the URL was extracted through, or
-        /// null to fetch directly.
-        /// </summary>
         HttpClient For(string? proxy);
     }
 
@@ -39,9 +35,6 @@ namespace ArgonFetch.Application.Services
             return _proxiedClients.GetOrAdd(proxy, CreateProxiedClient);
         }
 
-        /// <summary>
-        /// Proxy identity for logs, without the credentials the URL carries.
-        /// </summary>
         public static string Describe(string? proxy)
         {
             if (string.IsNullOrWhiteSpace(proxy))
@@ -66,10 +59,6 @@ namespace ArgonFetch.Application.Services
             return client;
         }
 
-        /// <summary>
-        /// Credentials in a proxy URL are not applied by WebProxy on their own, so they are
-        /// lifted out of the user info and attached explicitly.
-        /// </summary>
         private static WebProxy BuildWebProxy(string proxy)
         {
             var uri = new Uri(proxy);

--- a/src/ArgonFetch.Application/Services/MediaTags.cs
+++ b/src/ArgonFetch.Application/Services/MediaTags.cs
@@ -3,10 +3,6 @@ using System.Text;
 
 namespace ArgonFetch.Application.Services
 {
-    /// <summary>
-    /// What a downloaded file should say it is. Carried from the fetch that identified the media
-    /// to the stream that serves it, because by then only a cache key is left.
-    /// </summary>
     public record MediaTags(string? Title, string? Artist)
     {
         public static readonly MediaTags None = new(null, null);
@@ -14,13 +10,6 @@ namespace ArgonFetch.Application.Services
         public bool HasAny => !string.IsNullOrWhiteSpace(Title) || !string.IsNullOrWhiteSpace(Artist);
     }
 
-    /// <summary>
-    /// Names the file a download lands as.
-    /// <para>
-    /// Without this a caller that is not the web UI - which builds its own name from the fetch
-    /// response - saves the cache key, so a folder of downloads reads as a list of hashes.
-    /// </para>
-    /// </summary>
     public static class MediaFileName
     {
         // Characters Windows refuses outright, plus the separators that would turn a name into a
@@ -29,9 +18,6 @@ namespace ArgonFetch.Application.Services
 
         private const int MaxStemLength = 120;
 
-        /// <summary>
-        /// "Artist - Title.ext", or a plain fallback when the source named neither.
-        /// </summary>
         public static string For(MediaTags tags, string extension, string fallbackStem = "download")
         {
             var stem = Sanitize(Join(tags));
@@ -42,14 +28,6 @@ namespace ArgonFetch.Application.Services
             return stem + extension;
         }
 
-        /// <summary>
-        /// A Content-Disposition value carrying that name.
-        /// <para>
-        /// Written twice: the plain filename for anything that reads only ASCII, and the RFC 5987
-        /// form so a name with accents or another script survives. Clients that understand the
-        /// second prefer it, and the first stops the others saving mojibake.
-        /// </para>
-        /// </summary>
         public static string ContentDisposition(MediaTags tags, string extension, string fallbackStem = "download")
         {
             var fileName = For(tags, extension, fallbackStem);
@@ -70,8 +48,6 @@ namespace ArgonFetch.Application.Services
             if (string.IsNullOrWhiteSpace(artist))
                 return title;
 
-            // YouTube titles are usually written "Artist - Song" already, and prefixing the
-            // credit again produced "Rick Astley - Rick Astley - Never Gonna Give You Up".
             return title.StartsWith(artist, StringComparison.OrdinalIgnoreCase)
                 ? title
                 : $"{artist} - {title}";
@@ -83,7 +59,6 @@ namespace ArgonFetch.Application.Services
 
             foreach (var character in name)
             {
-                // Control characters would be legal in a name and unreadable in a listing.
                 if (char.IsControl(character) || Invalid.Contains(character))
                     continue;
 
@@ -92,8 +67,6 @@ namespace ArgonFetch.Application.Services
 
             var trimmed = cleaned.ToString().Trim();
 
-            // Long enough to keep a real title, short enough to leave room for the extension
-            // under the 255-byte limit most filesystems impose.
             if (trimmed.Length > MaxStemLength)
                 trimmed = trimmed[..MaxStemLength].TrimEnd();
 
@@ -101,10 +74,6 @@ namespace ArgonFetch.Application.Services
             return trimmed.TrimEnd('.', ' ');
         }
 
-        /// <summary>
-        /// The name reduced to characters a header can carry literally. Quotes and backslashes go
-        /// too, since they would end the quoted string early.
-        /// </summary>
         private static string AsciiFold(string name)
         {
             var folded = new StringBuilder(name.Length);

--- a/src/ArgonFetch.Application/Services/MediaUrlCacheService.cs
+++ b/src/ArgonFetch.Application/Services/MediaUrlCacheService.cs
@@ -27,10 +27,8 @@ namespace ArgonFetch.Application.Services
 
         public string CacheMediaUrls(string videoUrl, string audioUrl, string? proxy = null, MediaTags? tags = null, TimeSpan? expiration = null)
         {
-            // Generate a unique cache key
             var cacheKey = GenerateCacheKey(videoUrl, audioUrl);
 
-            // Store URLs in cache with expiration (default 1 hour)
             var cacheOptions = new MemoryCacheEntryOptions
             {
                 AbsoluteExpirationRelativeToNow = expiration ?? TimeSpan.FromHours(1)
@@ -62,10 +60,8 @@ namespace ArgonFetch.Application.Services
 
         public string CacheSingleUrl(string url, TimeSpan? expiration = null)
         {
-            // Generate a unique cache key for single URL
             var cacheKey = GenerateSingleUrlCacheKey(url);
 
-            // Store URL in cache with expiration (default 1 hour)
             var cacheOptions = new MemoryCacheEntryOptions
             {
                 AbsoluteExpirationRelativeToNow = expiration ?? TimeSpan.FromHours(1)
@@ -78,10 +74,8 @@ namespace ArgonFetch.Application.Services
 
         public string CacheSingleUrl(string url, bool isAudio, string? mimeType = null, string? proxy = null, MediaTags? tags = null, TimeSpan? expiration = null)
         {
-            // Generate a unique cache key for single URL
             var cacheKey = GenerateSingleUrlCacheKey(url);
 
-            // Store URL with format info in cache with expiration (default 1 hour)
             var cacheOptions = new MemoryCacheEntryOptions
             {
                 AbsoluteExpirationRelativeToNow = expiration ?? TimeSpan.FromHours(1)
@@ -91,14 +85,10 @@ namespace ArgonFetch.Application.Services
             {
                 Url = url,
                 IsAudio = isAudio,
-                // Carried so the stream endpoint serves exactly the format the fetch response
-                // advertised, instead of re-deriving it from a URL that has no extension.
                 MimeType = mimeType,
                 // Media URLs are signed for the IP that requested them, so the download has to
                 // leave through the same proxy the extraction did or the source answers 403.
                 Proxy = proxy,
-                // Kept with the url because by streaming time only a cache key is left, and a
-                // file with no title is what the download otherwise lands as.
                 Tags = tags ?? MediaTags.None,
                 CachedAt = DateTime.UtcNow
             };
@@ -110,7 +100,6 @@ namespace ArgonFetch.Application.Services
 
         public string? GetCachedSingleUrl(string cacheKey)
         {
-            // Try to get as new format first
             if (_cache.TryGetValue(CACHE_PREFIX + cacheKey, out object? cachedData))
             {
                 if (cachedData is CachedSingleUrl singleUrl)
@@ -119,7 +108,6 @@ namespace ArgonFetch.Application.Services
                 }
                 else if (cachedData is string url)
                 {
-                    // Legacy format - just URL string
                     return url;
                 }
             }
@@ -137,7 +125,6 @@ namespace ArgonFetch.Application.Services
                 }
                 else if (cachedData is string url)
                 {
-                    // Legacy format - assume video (since we don't know)
                     return (url, false, null, null, MediaTags.None);
                 }
             }
@@ -152,12 +139,10 @@ namespace ArgonFetch.Application.Services
 
         private string GenerateCacheKey(string videoUrl, string audioUrl)
         {
-            // Create a unique key based on URLs
             var combined = $"{videoUrl}|{audioUrl}";
             using var sha256 = SHA256.Create();
             var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(combined));
 
-            // Convert to URL-safe base64
             var base64 = Convert.ToBase64String(hashBytes)
                 .Replace('+', '-')
                 .Replace('/', '_')
@@ -169,11 +154,9 @@ namespace ArgonFetch.Application.Services
 
         private string GenerateSingleUrlCacheKey(string url)
         {
-            // Create a unique key based on single URL
             using var sha256 = SHA256.Create();
             var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(url));
 
-            // Convert to URL-safe base64
             var base64 = Convert.ToBase64String(hashBytes)
                 .Replace('+', '-')
                 .Replace('/', '_')

--- a/src/ArgonFetch.Application/Services/PlatformIdentifierService.cs
+++ b/src/ArgonFetch.Application/Services/PlatformIdentifierService.cs
@@ -16,9 +16,6 @@ namespace ArgonFetch.Application.Services
                 return Platform.SearchTerm;
             }
 
-            // Only the sources this application fetches by itself are named here. Anything a
-            // plugin handles was already dealt with before this was ever asked, and anything
-            // nobody handles is Unknown - which yt-dlp is welcome to try and report on.
             string hostname = uri.Host.ToLower();
 
             switch (hostname)

--- a/src/ArgonFetch.Application/Services/ProxyPool.cs
+++ b/src/ArgonFetch.Application/Services/ProxyPool.cs
@@ -2,18 +2,11 @@ namespace ArgonFetch.Application.Services
 {
     public interface IProxyPool
     {
-        /// <summary>Number of proxies loaded; 0 means fetches go out from the server's own IP.</summary>
         int Count { get; }
 
-        /// <summary>Next proxy in round-robin order, or null when no list is configured.</summary>
         string? Next();
     }
 
-    /// <summary>
-    /// Round-robins the proxies listed in the file at <c>PROXY_LIST_PATH</c> (one per line,
-    /// blank lines and # comments ignored) so repeated yt-dlp fetches do not all leave from
-    /// the same IP and trip a block.
-    /// </summary>
     public class ProxyPool : IProxyPool
     {
         private readonly string[] _proxies;
@@ -28,16 +21,11 @@ namespace ArgonFetch.Application.Services
             if (_proxies.Length == 0)
                 return null;
 
-            // Unsigned so the index stays valid once the counter wraps past int.MaxValue.
             var index = (uint)Interlocked.Increment(ref _cursor) % (uint)_proxies.Length;
 
             return _proxies[index];
         }
 
-        /// <summary>
-        /// Reads the proxy list. A missing or unreadable file is not fatal: the pool is simply
-        /// empty and fetches behave as they did before a list was configured.
-        /// </summary>
         public static string[] ReadList(string? path)
         {
             if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
@@ -50,11 +38,6 @@ namespace ArgonFetch.Application.Services
                 .ToArray();
         }
 
-        /// <summary>
-        /// Turns a plain <c>host:port</c> or a provider export like Webshare's
-        /// <c>host:port:user:pass</c> into the URL yt-dlp expects. Lines that already carry a
-        /// scheme are passed through untouched.
-        /// </summary>
         private static string Normalize(string line)
         {
             if (line.Contains("://"))

--- a/src/ArgonFetch.Application/Services/ProxyUrlBuilder.cs
+++ b/src/ArgonFetch.Application/Services/ProxyUrlBuilder.cs
@@ -6,10 +6,6 @@ namespace ArgonFetch.Application.Services
 {
     public interface IProxyUrlBuilder
     {
-        /// <summary>
-        /// Turns candidate formats into streamable renditions, best first. Each one is cached
-        /// with the media type and proxy it has to be served with.
-        /// </summary>
         List<MediaRenditionDto> BuildRenditions(
             IEnumerable<RenditionSource> sources,
             IMediaUrlCacheService cacheService,
@@ -47,14 +43,6 @@ namespace ArgonFetch.Application.Services
                 });
             }
 
-            // MP3 is offered explicitly rather than left implicit: it costs a conversion and a
-            // generation of quality, so it belongs in the list beside the sources it is made
-            // from - and stating its bitrate stops "MP3" from being the one option whose
-            // quality nobody can see.
-            //
-            // Not offered when the source is already MP3, as SoundCloud's is: re-encoding it at
-            // a higher bitrate produces a larger file that sounds worse, which is not a choice
-            // worth putting in front of anyone.
             if (isAudio && renditions.Count > 0 && !IsMp3(renditions[0]))
             {
                 renditions.Add(new MediaRenditionDto
@@ -66,7 +54,6 @@ namespace ArgonFetch.Application.Services
                     MimeType = "audio/mpeg",
                     UrlType = UrlType.Media,
                     Bitrate = MediaFormats.Mp3BitrateKbps,
-                    // Not reported: the length of a re-encode is not known before it runs.
                     FileSizeBytes = null,
                     ConvertTo = "mp3"
                 });
@@ -78,12 +65,6 @@ namespace ArgonFetch.Application.Services
         private static bool IsMp3(MediaRenditionDto rendition) =>
             rendition.MimeType.Equals("audio/mpeg", StringComparison.OrdinalIgnoreCase);
 
-        /// <summary>
-        /// The extension and media type the client will get. A recognised source container is
-        /// reported as-is because those bytes are passed through untouched - claiming ".mp3"
-        /// for Opus in WebM cost a needless FFmpeg pass and every tag the file carried.
-        /// Unknown containers still convert, so they keep advertising the converted format.
-        /// </summary>
         private static (string Extension, string MimeType) Describe(string? sourceExtension, bool isAudio)
         {
             var mimeType = MediaFormats.MimeTypeFor(sourceExtension, isAudio);

--- a/src/ArgonFetch.Application/Services/RenditionPicker.cs
+++ b/src/ArgonFetch.Application/Services/RenditionPicker.cs
@@ -1,9 +1,5 @@
 namespace ArgonFetch.Application.Services
 {
-    /// <summary>
-    /// One candidate format, stripped of the extractor's own types so the builders and this
-    /// picker do not have to know where it came from.
-    /// </summary>
     public record RenditionSource(
         string Url,
         string? Description,
@@ -12,25 +8,10 @@ namespace ArgonFetch.Application.Services
         double? Bitrate,
         long? FileSizeBytes);
 
-    /// <summary>
-    /// Chooses which formats to offer. Sources list a dozen or more renditions that differ in
-    /// ways nobody picking a download cares about, so this reduces them to a handful of
-    /// genuinely different steps, best first.
-    /// </summary>
     public static class RenditionPicker
     {
-        /// <summary>How many renditions to offer per source.</summary>
         public const int DefaultCount = 4;
 
-        /// <summary>
-        /// Video renditions, best first.
-        /// </summary>
-        /// <param name="perContainer">
-        /// Whether the source container reaches the caller. It does for formats served as they
-        /// are, and there WebM beside MP4 at one resolution is a real choice. Muxed video is
-        /// always delivered as MP4, so distinguishing sources there would offer the same
-        /// resolution twice under the same label.
-        /// </param>
         public static List<RenditionSource> PickVideo(
             IEnumerable<RenditionSource> candidates,
             int count = DefaultCount,
@@ -43,8 +24,6 @@ namespace ArgonFetch.Application.Services
                 : streamable.GroupBy(c => (c.Height ?? 0, string.Empty));
 
             var byResolution = groups
-                // MP4 sources win a tie: their codecs are the ones an MP4 is expected to carry,
-                // and muxing VP9 into one produces a file some players refuse.
                 .Select(group => group
                     .OrderByDescending(c => Container(c) == ".mp4")
                     .ThenByDescending(c => c.Bitrate ?? 0)
@@ -56,16 +35,6 @@ namespace ArgonFetch.Application.Services
             return Spread(byResolution, count);
         }
 
-        /// <summary>
-        /// Audio renditions, one per audible step per container.
-        /// <para>
-        /// Candidates are expected in the caller's own order of preference and stay in it: the
-        /// caller knows that Opus beats AAC at the same bitrate, and re-sorting on the raw
-        /// number here would quietly undo that. Bitrates are bucketed to the nearest 10 kbps,
-        /// so two encodes of the same step collapse - but only within one container, because
-        /// WebM and M4A at the same bitrate are a real choice for whoever has to play the file.
-        /// </para>
-        /// </summary>
         public static List<RenditionSource> PickAudio(IEnumerable<RenditionSource> candidates, int count = DefaultCount)
         {
             var distinctSteps = candidates
@@ -80,11 +49,6 @@ namespace ArgonFetch.Application.Services
         private static string Container(RenditionSource source) =>
             MediaFormats.NormalizeExtension(source.Extension)?.ToLowerInvariant() ?? string.Empty;
 
-        /// <summary>
-        /// Takes <paramref name="count"/> entries spread evenly across the list, always keeping
-        /// the first and last. Taking the top N instead would offer four near-identical high
-        /// quality options and no small one, which is the choice people actually want.
-        /// </summary>
         private static List<RenditionSource> Spread(List<RenditionSource> ordered, int count)
         {
             if (count < 1 || ordered.Count == 0)
@@ -100,8 +64,6 @@ namespace ArgonFetch.Application.Services
 
             for (var i = 0; i < count; i++)
             {
-                // Rounded rather than truncated so the steps stay even, and the last index is
-                // exactly the last entry.
                 var index = (int)Math.Round(i * (ordered.Count - 1) / (double)(count - 1));
 
                 if (!picked.Contains(ordered[index]))
@@ -113,15 +75,12 @@ namespace ArgonFetch.Application.Services
             return picked;
         }
 
-        /// <summary>Label for a picker: the resolution for video, the bitrate for audio.</summary>
         public static string Label(RenditionSource source, bool isAudio)
         {
             if (!isAudio && source.Height is > 0)
             {
                 var height = source.Height.Value;
 
-                // The exact line count stays, with the familiar name beside it: someone looking
-                // for 4K should not have to know that it means 2160p.
                 var tier = height switch
                 {
                     >= 4320 => " (8K)",
@@ -135,7 +94,6 @@ namespace ArgonFetch.Application.Services
             if (source.Bitrate is > 0)
                 return $"{Math.Round(source.Bitrate.Value)} kbps";
 
-            // Nothing quantitative to show; the source's own wording is better than nothing.
             return string.IsNullOrWhiteSpace(source.Description) ? "Unknown" : source.Description;
         }
     }

--- a/src/ArgonFetch.Application/Services/ToolPaths.cs
+++ b/src/ArgonFetch.Application/Services/ToolPaths.cs
@@ -2,36 +2,19 @@
 {
     public interface IToolPaths
     {
-        /// <summary>Directory the fetched tooling lives in.</summary>
         string ToolsDirectory { get; }
 
-        /// <summary>Full path of the yt-dlp binary, whether or not it exists yet.</summary>
         string YtDlpPath { get; }
 
-        /// <summary>Full path of the FFmpeg binary, whether or not it exists yet.</summary>
         string FfmpegPath { get; }
 
-        /// <summary>
-        /// A Netscape-format cookies file to extract with, or null when none is configured or
-        /// the configured one is not there. Sources that serve media only to a signed-in
-        /// session - Instagram serves nothing without one - need it; everything else ignores it.
-        /// </summary>
         string? CookiesPath { get; }
     }
 
-    /// <summary>
-    /// Where the media tools are kept. They are fetched at boot rather than baked into the
-    /// image, so the location has to be writable by the runtime user - <c>TOOLS_PATH</c> points
-    /// at it, and mounting a volume there turns the download into a one-off rather than a cost
-    /// paid on every restart.
-    /// </summary>
     public class ToolPaths : IToolPaths
     {
         public ToolPaths(string? toolsDirectory, string? cookiesPath = null)
         {
-            // Checked once here rather than on every fetch: a path pointing at nothing is a
-            // configuration mistake, and passing it to yt-dlp fails every extraction with an
-            // error about cookies rather than about the media.
             CookiesPath = !string.IsNullOrWhiteSpace(cookiesPath) && File.Exists(cookiesPath)
                 ? cookiesPath
                 : null;

--- a/src/ArgonFetch.Application/Services/YtDlpErrors.cs
+++ b/src/ArgonFetch.Application/Services/YtDlpErrors.cs
@@ -1,30 +1,15 @@
 ﻿namespace ArgonFetch.Application.Services
 {
-    /// <summary>
-    /// Reads what yt-dlp printed when a fetch failed, so the API can say why rather than
-    /// treating every failure as a missing resource.
-    /// </summary>
     public static class YtDlpErrors
     {
-        /// <summary>
-        /// Whether the source refused because the media is DRM protected - SoundCloud does this
-        /// for licensed tracks. The track exists and the link is right, so reporting it as
-        /// missing sends the reader looking for a mistake that is not there.
-        /// </summary>
         public static bool IsDrmProtected(IEnumerable<string>? errorOutput) =>
             Mentions(errorOutput, "DRM");
 
-        /// <summary>
-        /// Whether the source refused because nobody was signed in. Instagram answers this way
-        /// for practically everything now, and an age-gated YouTube video does the same, so the
-        /// answer is a cookies file rather than a different link.
-        /// </summary>
         public static bool NeedsSignedInSession(IEnumerable<string>? errorOutput) =>
             Mentions(errorOutput, "login required") ||
             Mentions(errorOutput, "log in") ||
             Mentions(errorOutput, "sign in") ||
             Mentions(errorOutput, "cookies") ||
-            // Instagram's own wording when it serves nothing to a signed-out request.
             Mentions(errorOutput, "empty media response") ||
             Mentions(errorOutput, "rate-limit reached");
 

--- a/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
@@ -24,10 +24,6 @@ namespace ArgonFetch.Infrastructure.Services
             _logger = logger;
         }
 
-        /// <summary>
-        /// Length the upstream reports, or null when it does not report one. A failure here is
-        /// not fatal - the caller simply cannot declare Content-Length and the response is chunked.
-        /// </summary>
         public async Task<long?> GetContentLengthAsync(
             string url,
             string? proxy = null,
@@ -63,13 +59,8 @@ namespace ArgonFetch.Infrastructure.Services
             ByteRange? range = null,
             CancellationToken cancellationToken = default)
         {
-            // Counts what has already been handed to the caller. Once any byte is written,
-            // restarting the download would append a second copy of the file, so a failure
-            // past that point has to propagate rather than fall back.
             var output = new OutputTracker();
 
-            // Probe for range support first. This writes nothing, so failing here is
-            // always safe to recover from.
             long? contentLength = null;
             var acceptsRanges = false;
             var probeSucceeded = false;
@@ -113,25 +104,15 @@ namespace ArgonFetch.Infrastructure.Services
             }
             catch (OperationCanceledException)
             {
-                // The caller went away or the request was aborted; retrying is pointless.
                 throw;
             }
             catch (Exception ex) when (output.BytesWritten == 0)
             {
-                // Nothing has reached the caller yet, so starting over is safe.
                 _logger.LogWarning(ex, "Accelerated download failed before writing any output, falling back to single connection");
                 await DownloadSingleConnectionAsync(url, outputStream, progress, output, proxy, range, cancellationToken);
             }
         }
 
-        /// <summary>
-        /// Asks for the first byte to learn the resource's length and whether it serves ranges.
-        /// <para>
-        /// A HEAD request would be the obvious probe, but media hosts answer 403 to both HEAD
-        /// and an unranged GET for signed URLs, so the only shape that reliably works is the
-        /// ranged GET the chunked download uses anyway.
-        /// </para>
-        /// </summary>
         private async Task<(long? ContentLength, bool AcceptsRanges)> ProbeAsync(
             string url,
             string? proxy,
@@ -146,8 +127,6 @@ namespace ArgonFetch.Infrastructure.Services
 
             response.EnsureSuccessStatusCode();
 
-            // 206 answers with the total after the slash in "bytes 0-0/12345"; a host that
-            // ignored the range answered 200 and reported the whole length instead.
             if (response.StatusCode == System.Net.HttpStatusCode.PartialContent)
             {
                 return (response.Content.Headers.ContentRange?.Length, true);
@@ -156,10 +135,6 @@ namespace ArgonFetch.Infrastructure.Services
             return (response.Content.Headers.ContentLength, false);
         }
 
-        /// <summary>
-        /// Tracks how much of the output stream has already been written, so callers can tell
-        /// whether restarting a transfer would duplicate bytes the consumer has already seen.
-        /// </summary>
         private sealed class OutputTracker
         {
             public long BytesWritten { get; private set; }
@@ -212,8 +187,6 @@ namespace ArgonFetch.Infrastructure.Services
 
                     var data = await inFlight.Dequeue();
 
-                    // Counted before the write: a write that throws may still have pushed
-                    // bytes to the consumer, so the output can no longer be restarted.
                     output.Add(data.Length);
                     await outputStream.WriteAsync(data, 0, data.Length, cancellationToken);
 
@@ -226,8 +199,6 @@ namespace ArgonFetch.Infrastructure.Services
             }
             catch
             {
-                // Observe the downloads still running so their failures don't resurface
-                // later as unobserved task exceptions.
                 foreach (var pending in inFlight)
                 {
                     _ = pending.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
@@ -269,7 +240,6 @@ namespace ArgonFetch.Infrastructure.Services
         {
             var httpClient = _mediaHttpClients.For(proxy);
 
-            // Ranged from the first byte: an unranged GET is refused for signed media URLs.
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.Headers.Range = range.HasValue
                 ? new RangeHeaderValue(range.Value.From, range.Value.To)

--- a/src/ArgonFetch.Infrastructure/Services/ApplicationInfoService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/ApplicationInfoService.cs
@@ -22,10 +22,6 @@ public class ApplicationInfoService : IApplicationInfoService
 
     private static string LoadVersion()
     {
-        // The version is stamped into the assembly at build time from
-        // application.properties (see ReadVersionFromProperties in ArgonFetch.API.csproj),
-        // so the assembly is the reliable source at runtime - the properties file itself
-        // is not part of the published output.
         return LoadVersionFromAssembly() ?? LoadVersionFromPropertiesFile() ?? UnknownVersion;
     }
 
@@ -37,8 +33,6 @@ public class ApplicationInfoService : IApplicationInfoService
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
             .InformationalVersion;
 
-        // AssemblyInformationalVersion carries the source revision as "0.1.1+<commit sha>"
-        // when SourceLink is active; only the version part is wanted here.
         if (!string.IsNullOrWhiteSpace(informationalVersion))
         {
             var version = informationalVersion.Split('+', 2)[0];
@@ -50,8 +44,6 @@ public class ApplicationInfoService : IApplicationInfoService
 
         var assemblyVersion = assembly.GetName().Version;
 
-        // AssemblyVersion is always four-part; application.properties uses three,
-        // so drop a trailing zero revision to keep the two in sync.
         return assemblyVersion is null
             ? null
             : assemblyVersion.Revision == 0
@@ -63,14 +55,11 @@ public class ApplicationInfoService : IApplicationInfoService
     {
         try
         {
-            // Development fallback: application.properties lives at the repository root.
             var currentDirectory = Directory.GetCurrentDirectory();
             var propertiesPath = Path.Combine(currentDirectory, "application.properties");
 
-            // Check if running from src/ArgonFetch.API directory
             if (!File.Exists(propertiesPath))
             {
-                // Try going up directories to find the root
                 var parentPath = Path.Combine(currentDirectory, "..", "..", "application.properties");
                 if (File.Exists(parentPath))
                 {

--- a/src/ArgonFetch.Infrastructure/Services/FfmpegStreamingService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/FfmpegStreamingService.cs
@@ -7,8 +7,6 @@ namespace ArgonFetch.Infrastructure.Services
 {
     public class FfmpegStreamingService : IFfmpegStreamingService
     {
-        // Shared with the media HttpClient so the User-Agent that avoids upstream 403s
-        // is defined in exactly one place.
         private const string UserAgent = MediaHttpClientDefaults.UserAgent;
 
         private readonly IHttpClientFactory _httpClientFactory;
@@ -35,9 +33,6 @@ namespace ArgonFetch.Infrastructure.Services
 
             var processStartInfo = CreateProcessStartInfo(ffmpegPath);
 
-            // Use HTTP input for better streaming support
-            // Add user-agent header to avoid 403 errors from YouTube
-            // Arguments are passed as separate tokens so a URL can never be parsed as an option.
             processStartInfo.ArgumentList.Add("-user_agent");
             processStartInfo.ArgumentList.Add(UserAgent);
             AddProxy(processStartInfo, proxy);
@@ -88,10 +83,8 @@ namespace ArgonFetch.Infrastructure.Services
                 process.Start();
                 process.BeginErrorReadLine();
 
-                // Stream the output to the client
                 await process.StandardOutput.BaseStream.CopyToAsync(outputStream, 81920, cancellationToken);
 
-                // Wait for process to complete
                 await process.WaitForExitAsync(cancellationToken);
 
                 if (process.ExitCode != 0)
@@ -103,7 +96,6 @@ namespace ArgonFetch.Infrastructure.Services
             }
             catch (OperationCanceledException)
             {
-                // Client disconnected, kill the process
                 if (!process.HasExited)
                 {
                     try
@@ -141,7 +133,6 @@ namespace ArgonFetch.Infrastructure.Services
 
             var processStartInfo = CreateProcessStartInfo(ffmpegPath);
 
-            // Arguments are passed as separate tokens so a URL can never be parsed as an option.
             processStartInfo.ArgumentList.Add("-user_agent");
             processStartInfo.ArgumentList.Add(UserAgent);
             AddProxy(processStartInfo, proxy);
@@ -150,7 +141,6 @@ namespace ArgonFetch.Infrastructure.Services
 
             if (isAudio)
             {
-                // Convert any audio format to MP3
                 processStartInfo.ArgumentList.Add("-vn");        // Disable video
                 // ID3v2.3 rather than the default 2.4: a fair number of players and Windows
                 // Explorer read tags only from the older revision.
@@ -159,7 +149,6 @@ namespace ArgonFetch.Infrastructure.Services
                 processStartInfo.ArgumentList.Add("-c:a");
                 processStartInfo.ArgumentList.Add("mp3");        // Convert audio to MP3
                 processStartInfo.ArgumentList.Add("-b:a");
-                // The rendition list advertises this same number, so it comes from one place.
                 processStartInfo.ArgumentList.Add($"{MediaFormats.Mp3BitrateKbps}k");
                 processStartInfo.ArgumentList.Add("-f");
                 processStartInfo.ArgumentList.Add("mp3");        // Force MP3 format
@@ -167,7 +156,6 @@ namespace ArgonFetch.Infrastructure.Services
             }
             else
             {
-                // Convert any video format to MP4 (with audio if present)
                 processStartInfo.ArgumentList.Add("-c:v");
                 processStartInfo.ArgumentList.Add("libx264");    // Use H.264 codec for video
                 processStartInfo.ArgumentList.Add("-preset");
@@ -209,10 +197,8 @@ namespace ArgonFetch.Infrastructure.Services
                 process.Start();
                 process.BeginErrorReadLine();
 
-                // Stream the output to the client
                 await process.StandardOutput.BaseStream.CopyToAsync(outputStream, 81920, cancellationToken);
 
-                // Wait for process to complete
                 await process.WaitForExitAsync(cancellationToken);
 
                 if (process.ExitCode != 0)
@@ -224,7 +210,6 @@ namespace ArgonFetch.Infrastructure.Services
             }
             catch (OperationCanceledException)
             {
-                // Client disconnected, kill the process
                 if (!process.HasExited)
                 {
                     try
@@ -263,10 +248,6 @@ namespace ArgonFetch.Infrastructure.Services
             };
         }
 
-        /// <summary>
-        /// FFmpeg treats a leading dash as an option and can read local paths as input,
-        /// so only absolute http(s) URLs are accepted as media sources.
-        /// </summary>
         private static void ValidateMediaUrl(string url, string parameterName)
         {
             if (string.IsNullOrWhiteSpace(url))
@@ -281,18 +262,6 @@ namespace ArgonFetch.Infrastructure.Services
             }
         }
 
-        /// <summary>
-        /// Renders the argument list for logging only - it is never handed to the process.
-        /// </summary>
-        /// <summary>
-        /// Writes what the media is into the file itself.
-        /// <para>
-        /// Text only, no cover art. Embedding a picture needs a seekable output, and this writes
-        /// to a pipe: given both, FFmpeg silently drops the picture and every tag with it, exit
-        /// code zero and nothing on stderr. Artwork would mean converting to a file first and
-        /// sending it afterwards, which costs the whole conversion before the first byte moves.
-        /// </para>
-        /// </summary>
         private static void AddTags(ProcessStartInfo processStartInfo, MediaTags? tags)
         {
             if (tags is null || !tags.HasAny)
@@ -308,7 +277,6 @@ namespace ArgonFetch.Infrastructure.Services
             {
                 processStartInfo.ArgumentList.Add("-metadata");
                 processStartInfo.ArgumentList.Add($"artist={tags.Artist}");
-                // Written to both: players disagree on which one names the performer.
                 processStartInfo.ArgumentList.Add("-metadata");
                 processStartInfo.ArgumentList.Add($"album_artist={tags.Artist}");
             }
@@ -334,14 +302,11 @@ namespace ArgonFetch.Infrastructure.Services
 
         private string? GetFfmpegPath()
         {
-            // The fetched binary wins: in a container it is the only one, and on a developer
-            // machine it is the same build the deployment runs rather than whatever is installed.
             if (File.Exists(_toolPaths.FfmpegPath))
             {
                 return _toolPaths.FfmpegPath;
             }
 
-            // Try to find ffmpeg in PATH
             var paths = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator) ?? Array.Empty<string>();
 
             foreach (var path in paths)
@@ -353,7 +318,6 @@ namespace ArgonFetch.Infrastructure.Services
                 }
             }
 
-            // Check common installation locations
             var commonPaths = new[]
             {
                 "/usr/bin/ffmpeg",

--- a/src/ArgonFetch.Infrastructure/Services/MediaToolsService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/MediaToolsService.cs
@@ -9,20 +9,6 @@ using System.Runtime.InteropServices;
 
 namespace ArgonFetch.Infrastructure.Services
 {
-    /// <summary>
-    /// Owns the media tooling: fetches yt-dlp and FFmpeg when the app boots and keeps yt-dlp
-    /// current afterwards.
-    /// <para>
-    /// Baking them into the image pinned every deployment to whatever was current on build day,
-    /// and yt-dlp breaks whenever the sites it extracts from change. Fetching at boot means a
-    /// restart is enough to recover, and the image ships without media tooling at all - which is
-    /// also what lets it run on a minimal base with no package manager involved.
-    /// </para>
-    /// <para>
-    /// The app reports itself as under maintenance while this runs, so a fetch arriving before
-    /// the binaries exist is refused with a reason instead of failing on a missing file.
-    /// </para>
-    /// </summary>
     public class MediaToolsService : BackgroundService
     {
         private static readonly TimeSpan UpdateInterval = TimeSpan.FromHours(12);
@@ -57,9 +43,6 @@ namespace ArgonFetch.Infrastructure.Services
 
                 if (!File.Exists(_paths.FfmpegPath))
                 {
-                    // FFmpeg is fetched once and then left alone: it is a stable dependency,
-                    // unlike yt-dlp, and the archive is large enough that re-fetching it on a
-                    // timer would cost far more than it is worth.
                     using (_maintenance.Begin("Downloading FFmpeg"))
                     {
                         await TryDownloadFfmpegAsync(stoppingToken);
@@ -77,8 +60,6 @@ namespace ArgonFetch.Infrastructure.Services
 
                     await TryUpdateYtDlpAsync(stoppingToken);
 
-                    // Logged rather than served: which extractor build is running is useful
-                    // when debugging, and nothing a caller needs to be told.
                     await LogVersionsAsync(stoppingToken);
                 }
 
@@ -88,17 +69,11 @@ namespace ArgonFetch.Infrastructure.Services
                 }
                 catch (OperationCanceledException)
                 {
-                    // Shutting down.
                     return;
                 }
             }
         }
 
-        /// <summary>
-        /// Fetches the standalone yt-dlp build for the current platform. The generic "yt-dlp"
-        /// asset needs a Python interpreter beside it; the per-platform ones do not, which is
-        /// what keeps Python out of the image.
-        /// </summary>
         private async Task TryDownloadYtDlpAsync(CancellationToken cancellationToken)
         {
             var assetName = OperatingSystem.IsWindows()
@@ -129,16 +104,10 @@ namespace ArgonFetch.Infrastructure.Services
             }
             catch (Exception ex)
             {
-                // Retried on the next cycle. Failing to start over it would take the whole app
-                // down for what is usually a transient network problem.
                 _logger.LogError(ex, "Could not download yt-dlp. Fetching will be retried later.");
             }
         }
 
-        /// <summary>
-        /// Fetches a static FFmpeg build and lifts the single binary out of the archive. The GPL
-        /// build is the one carrying libx264, which the conversion path needs.
-        /// </summary>
         private async Task TryDownloadFfmpegAsync(CancellationToken cancellationToken)
         {
             var isWindows = OperatingSystem.IsWindows();
@@ -155,9 +124,6 @@ namespace ArgonFetch.Infrastructure.Services
 
                 using var timeout = Bounded(cancellationToken);
 
-                // Both archive formats need to seek, which a response stream cannot do, so the
-                // download lands on disk first. A file rather than memory: the archive runs to
-                // tens of megabytes and a container is usually the tighter on RAM of the two.
                 var archivePath = Path.Combine(_paths.ToolsDirectory, assetName);
 
                 try
@@ -192,8 +158,6 @@ namespace ArgonFetch.Infrastructure.Services
             }
             catch (Exception ex)
             {
-                // Conversion is the only thing that needs FFmpeg, and it is now the exception
-                // rather than the rule, so the app stays up and retries on the next cycle.
                 _logger.LogError(ex, "Could not download FFmpeg. Conversion will not work until it succeeds.");
             }
         }
@@ -226,10 +190,6 @@ namespace ArgonFetch.Infrastructure.Services
             await WriteExecutableAsync(_paths.FfmpegPath, content, cancellationToken);
         }
 
-        /// <summary>
-        /// Writes to a temporary name and moves it into place, so a download that dies halfway
-        /// cannot leave a truncated binary that looks installed.
-        /// </summary>
         private static async Task WriteExecutableAsync(string path, Stream content, CancellationToken cancellationToken)
         {
             var partialPath = path + ".partial";
@@ -276,7 +236,6 @@ namespace ArgonFetch.Infrastructure.Services
 
             try
             {
-                // Bound the attempt so a hung download can't keep the timer from firing again.
                 using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 timeout.CancelAfter(UpdateTimeout);
 
@@ -305,10 +264,6 @@ namespace ArgonFetch.Infrastructure.Services
             }
         }
 
-        /// <summary>
-        /// Records which tool builds are in use. Kept to the log rather than any endpoint:
-        /// naming exact versions to callers only helps someone matching them to known exploits.
-        /// </summary>
         private async Task LogVersionsAsync(CancellationToken cancellationToken)
         {
             _logger.LogInformation(
@@ -332,7 +287,6 @@ namespace ArgonFetch.Infrastructure.Services
                 if (exitCode != 0)
                     return null;
 
-                // ffmpeg answers with a whole banner; only its first line carries the version.
                 var firstLine = stdout.Split('\n').FirstOrDefault()?.Trim();
 
                 return string.IsNullOrWhiteSpace(firstLine) ? null : firstLine;

--- a/src/ArgonFetch.Tests/ArchiveNamingTests.cs
+++ b/src/ArgonFetch.Tests/ArchiveNamingTests.cs
@@ -15,8 +15,6 @@ namespace ArgonFetch.Tests
         [Fact]
         public void Unique_SeparatesTracksThatShareAName()
         {
-            // A release can carry the same title twice - an edit and its instrumental resolve to
-            // the same tags - and a zip holding two identical names unpacks to one file.
             var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             Assert.Equal("Song.webm", StreamArchiveQueryHandler.Unique("Song.webm", used));

--- a/src/ArgonFetch.Tests/MaintenanceStateTests.cs
+++ b/src/ArgonFetch.Tests/MaintenanceStateTests.cs
@@ -33,7 +33,6 @@ namespace ArgonFetch.Tests
 
             first.Dispose();
 
-            // The second run is still going, so the app is not back yet.
             Assert.Equal("Migrating database", state.Activity);
 
             second.Dispose();
@@ -52,7 +51,6 @@ namespace ArgonFetch.Tests
             scope.Dispose();
             scope.Dispose();
 
-            // Disposing one scope twice must not retire the identically named one still running.
             Assert.Equal("Updating yt-dlp", state.Activity);
         }
     }

--- a/src/ArgonFetch.Tests/MediaContentIdentifierTests.cs
+++ b/src/ArgonFetch.Tests/MediaContentIdentifierTests.cs
@@ -9,9 +9,6 @@ namespace ArgonFetch.Tests
         [Theory]
         [InlineData("https://www.youtube.com/playlist?list=PLFgquLnL59alCl", ContentType.Playlist)]
         [InlineData("https://www.youtube.com/playlist?list=RDabc123", ContentType.YouTubeRadio)]
-        // A watch link that also names a list is one video seen in that list's context, which is
-        // what YouTube plays. Reading it as the list handed back hundreds of entries to someone
-        // who asked for one video.
         [InlineData("https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLFgquLnL59alCl", ContentType.Media)]
         [InlineData("https://www.youtube.com/watch?v=dQw4w9WgXcQ", ContentType.Media)]
         public async Task IdentifyContent_TellsAListFromAVideoInOne(string url, ContentType expected)
@@ -28,8 +25,6 @@ namespace ArgonFetch.Tests
         }
 
         [Theory]
-        // SoundCloud lists a set as bare links and nothing else, so without this every row of a
-        // 329-track set read "Unknown" and there was no way to pick one.
         [InlineData("https://soundcloud.com/sweet-medicine/sweet-medicine-w-odyssee-breezin", "Sweet Medicine W Odyssee Breezin")]
         [InlineData("https://soundcloud.com/artist/some_track_name", "Some Track Name")]
         [InlineData("https://example.com/", null)]

--- a/src/ArgonFetch.Tests/MediaFileNameTests.cs
+++ b/src/ArgonFetch.Tests/MediaFileNameTests.cs
@@ -18,14 +18,12 @@ namespace ArgonFetch.Tests
         [InlineData("Artist", "Title\\With\\Slashes", "Artist - TitleWithSlashes.mp3")]
         public void For_DropsCharactersAFilesystemRefuses(string artist, string title, string expected)
         {
-            // Stripped rather than substituted: "AC_DC" is not what anyone wanted either.
             Assert.Equal(expected, MediaFileName.For(new MediaTags(title, artist), ".mp3"));
         }
 
         [Fact]
         public void For_DoesNotRepeatTheArtistTheTitleAlreadyNames()
         {
-            // YouTube titles are usually written "Artist - Song" to begin with.
             var tags = new MediaTags("Rick Astley - Never Gonna Give You Up", "Rick Astley");
 
             Assert.Equal("Rick Astley - Never Gonna Give You Up.mp4", MediaFileName.For(tags, ".mp4"));
@@ -58,7 +56,6 @@ namespace ArgonFetch.Tests
         {
             var name = MediaFileName.For(new MediaTags(new string('x', 400), "Artist"), ".mp3");
 
-            // Most filesystems stop at 255 bytes, and the extension has to fit too.
             Assert.True(name.Length < 140, $"name was {name.Length} characters");
             Assert.EndsWith(".mp3", name);
         }
@@ -76,7 +73,6 @@ namespace ArgonFetch.Tests
         {
             var header = MediaFileName.ContentDisposition(new MediaTags("言って。", "ヨルシカ"), ".webm");
 
-            // The quoted form must not carry raw non-ASCII, and must not break out of its quotes.
             var quoted = header.Split('"')[1];
             Assert.All(quoted, c => Assert.InRange(c, ' ', '~'));
             Assert.Contains("filename*=UTF-8''", header);

--- a/src/ArgonFetch.Tests/ProviderRegistryTests.cs
+++ b/src/ArgonFetch.Tests/ProviderRegistryTests.cs
@@ -27,8 +27,6 @@ namespace ArgonFetch.Tests
         [Fact]
         public void For_SettlesAClashByTheOrderTheOperatorInstalledThem()
         {
-            // Two plugins wanting the same link is a decision for whoever chose them, not for
-            // whichever one happened to load first.
             var registry = Registry(
                 Plugin("spotify-fork", new StubProvider("spotify-fork", @"^https?://([\w-]+\.)*spotify\.com/")),
                 Plugin("spotify", new StubProvider("spotify", @"^https?://([\w-]+\.)*spotify\.com/")));
@@ -39,8 +37,6 @@ namespace ArgonFetch.Tests
         [Fact]
         public void For_TreatsAProviderThatThrowsAsNotInterested()
         {
-            // CanHandle is asked of every plugin on every request, including for sources it has
-            // nothing to do with, so one that throws must not break an unrelated download.
             var registry = Registry(
                 Plugin("broken", new ThrowingProvider()),
                 Plugin("spotify", new StubProvider("spotify", @"^https?://([\w-]+\.)*spotify\.com/")));
@@ -51,8 +47,6 @@ namespace ArgonFetch.Tests
         [Fact]
         public void For_IgnoresAPatternThatDoesNotCompile()
         {
-            // A typo in one pattern costs that pattern. Taking the plugin out entirely over it
-            // would help nobody, and the working patterns beside it are still worth having.
             var registry = Registry(Plugin("broken-pattern", new BadPatternProvider(
                 "broken-pattern", "([unclosed", @"^https?://([\w-]+\.)*spotify\.com/")));
 
@@ -62,8 +56,6 @@ namespace ArgonFetch.Tests
         [Fact]
         public void For_AsksTheProviderOnlyAfterAPatternMatched()
         {
-            // The throwing provider claims every link, so if it were consulted for this one the
-            // exception would be swallowed and it would be the winner that never ran.
             var registry = Registry(
                 Plugin("spotify", new StubProvider("spotify", @"^https?://([\w-]+\.)*spotify\.com/")));
 
@@ -130,8 +122,6 @@ namespace ArgonFetch.Tests
         [InlineData("spotify", "spotify", null)]
         [InlineData("spotify@1.2.0", "spotify", "1.2.0")]
         [InlineData("  spotify @ 1.2.0  ", "spotify", "1.2.0")]
-        // A trailing separator with nothing after it asks for the newest, rather than for a
-        // version named the empty string.
         [InlineData("spotify@", "spotify", null)]
         public void Parse_ReadsAnIdAndAnOptionalPinnedVersion(string request, string id, string? version)
         {

--- a/src/ArgonFetch.Tests/ProxyUrlBuilderTests.cs
+++ b/src/ArgonFetch.Tests/ProxyUrlBuilderTests.cs
@@ -17,7 +17,6 @@ namespace ArgonFetch.Tests
 
             var renditions = builder.BuildRenditions([AudioSource(".webm")], CacheStub(), isAudio: true);
 
-            // Opus in WebM used to be advertised as ".mp3", which forced a needless re-encode.
             Assert.Equal(".webm", renditions[0].FileExtension);
             Assert.Equal("audio/webm", renditions[0].MimeType);
         }
@@ -29,7 +28,6 @@ namespace ArgonFetch.Tests
 
             var renditions = builder.BuildRenditions([AudioSource(".sph")], CacheStub(), isAudio: true);
 
-            // Unknown containers are still converted, so the converted format is what is promised.
             Assert.Equal(".mp3", renditions[0].FileExtension);
             Assert.Equal("audio/mpeg", renditions[0].MimeType);
         }
@@ -59,15 +57,12 @@ namespace ArgonFetch.Tests
             Assert.Equal(".mp3", converted.FileExtension);
             Assert.Equal("192 kbps", converted.Label);
 
-            // The conversion streams from the same cached source it is made from.
             Assert.Equal(renditions[0].Key, converted.Key);
         }
 
         [Fact]
         public void BuildRenditions_SkipsTheMp3Conversion_WhenTheSourceIsAlreadyMp3()
         {
-            // SoundCloud serves MP3 directly. Re-encoding it at a higher bitrate produces a
-            // bigger file that sounds worse, so there is nothing to offer.
             var renditions = new ProxyUrlBuilder().BuildRenditions(
                 [new RenditionSource("https://example.test/mp3", "128 kbps", ".mp3", null, 128, 2_200_000)],
                 CacheStub(),

--- a/src/ArgonFetch.Tests/RangeHeaderTests.cs
+++ b/src/ArgonFetch.Tests/RangeHeaderTests.cs
@@ -12,9 +12,7 @@ namespace ArgonFetch.Tests
         [InlineData("bytes=-200", 800, 999)]
         [InlineData("bytes=0-", 0, 999)]
         [InlineData("bytes=999-999", 999, 999)]
-        // An end past the resource is clamped, which is what clients expect.
         [InlineData("bytes=900-5000", 900, 999)]
-        // A suffix longer than the resource is the whole resource.
         [InlineData("bytes=-5000", 0, 999)]
         [InlineData(" bytes=10-20 ", 10, 20)]
         [InlineData("BYTES=10-20", 10, 20)]
@@ -43,14 +41,12 @@ namespace ArgonFetch.Tests
         [InlineData("bytes=0-99,200-299")] // multipart, which this server does not serve
         public void Parse_IgnoresWhatItCannotHonour(string? header)
         {
-            // Ignored means the whole resource is served, which is always a valid answer.
             Assert.Equal(RangeRequest.None, RangeHeader.Parse(header, Total, out _));
         }
 
         [Fact]
         public void Parse_IgnoresRangesWhenTheLengthIsUnknown()
         {
-            // Without a length there is nothing to resolve "bytes=-200" or an open end against.
             Assert.Equal(RangeRequest.None, RangeHeader.Parse("bytes=0-99", 0, out _));
         }
     }

--- a/src/ArgonFetch.Tests/RenditionPickerTests.cs
+++ b/src/ArgonFetch.Tests/RenditionPickerTests.cs
@@ -18,7 +18,6 @@ namespace ArgonFetch.Tests
 
             Assert.Equal(["2160p (4K)", "1080p", "720p"], picked.Select(p => RenditionPicker.Label(p, isAudio: false)));
 
-            // The better encode of the duplicated resolution is the one kept.
             Assert.Equal(4000, picked[1].Bitrate);
         }
 
@@ -30,8 +29,6 @@ namespace ArgonFetch.Tests
 
             Assert.Equal(4, picked.Count);
 
-            // Taking the top four would offer no small download at all, which is the choice
-            // someone on a slow connection is actually after.
             Assert.Equal("2160p (4K)", RenditionPicker.Label(picked[0], isAudio: false));
             Assert.Equal("144p", RenditionPicker.Label(picked[^1], isAudio: false));
         }
@@ -39,9 +36,6 @@ namespace ArgonFetch.Tests
         [Fact]
         public void PickAudio_CollapsesBitratesWithinOneContainer_ButKeepsBothContainers()
         {
-            // The order a caller hands in reflects Opus being worth more than AAC at the same
-            // bitrate, so the Opus entry leads - but the M4A is a different file type, and
-            // whether a player can read it is exactly the choice worth offering.
             var picked = RenditionPicker.PickAudio([Audio(128.9), Audio(129.5, ".m4a"), Audio(126, ".webm"), Audio(48)]);
 
             Assert.Equal([".webm", ".m4a", ".webm"], picked.Select(p => p.Extension));

--- a/src/ArgonFetch.Tests/YtDlpErrorsTests.cs
+++ b/src/ArgonFetch.Tests/YtDlpErrorsTests.cs
@@ -13,12 +13,10 @@ namespace ArgonFetch.Tests
         [Fact]
         public void IsDrmProtected_IgnoresOtherFailures()
         {
-            // A missing video really is missing; only DRM gets the different answer.
             Assert.False(YtDlpErrors.IsDrmProtected(["ERROR: [youtube] abc: Video unavailable"]));
         }
 
         [Theory]
-        // Instagram's wording when it serves nothing to a signed-out request.
         [InlineData("ERROR: [Instagram] ABC: Instagram sent an empty media response. Check if this post is accessible in your browser without being logged-in.")]
         [InlineData("ERROR: [youtube] xyz: Sign in to confirm your age. Use --cookies-from-browser or --cookies.")]
         [InlineData("ERROR: [instagram] Requested content is not available, rate-limit reached or login required.")]
@@ -33,8 +31,6 @@ namespace ArgonFetch.Tests
         [InlineData(null)]
         public void NeedsSignedInSession_LeavesOtherFailuresAlone(string? error)
         {
-            // Only refusals a cookies file can actually fix should say so; the rest are still
-            // "not found", and telling someone to export cookies would waste their time.
             Assert.False(YtDlpErrors.NeedsSignedInSession(error is null ? null : [error]));
         }
 

--- a/template.development.env
+++ b/template.development.env
@@ -4,3 +4,13 @@
 # ASP.NET Core Configuration
 ASPNETCORE_ENVIRONMENT=Development
 ASPNETCORE_URLS=http://localhost:5000
+
+# Plugins
+# Sources yt-dlp cannot fetch on its own are plugins, installed by name rather than built in.
+# Without these, Spotify and TikTok links will not resolve. Downloaded once at boot and checked
+# against the hash the repository published.
+Plugins__Repositories__0=https://raw.githubusercontent.com/ArgonFetch/ArgonFetchPlugins/repo/index.json
+Plugins__Install__0=spotify
+Plugins__Install__1=tiktok
+# Where they are kept. Matches the volume the compose file mounts, so a restart reuses them.
+Plugins__Path=/plugins

--- a/template.env
+++ b/template.env
@@ -8,6 +8,16 @@ ASPNETCORE_ENVIRONMENT=Production
 # docs.argonfetch.dev is listed so the API playground in the documentation can send
 # real requests to this instance.
 CORS_ALLOWED_ORIGINS=https://app.argonfetch.dev,https://docs.argonfetch.dev
+# Plugins
+# Sources yt-dlp cannot fetch on its own are plugins, installed by name rather than built in.
+# Without these, Spotify and TikTok links will not resolve. Downloaded once at boot and checked
+# against the hash the repository published.
+Plugins__Repositories__0=https://raw.githubusercontent.com/ArgonFetch/ArgonFetchPlugins/repo/index.json
+Plugins__Install__0=spotify
+Plugins__Install__1=tiktok
+# Where they are kept. Matches the volume the compose file mounts, so a restart reuses them.
+Plugins__Path=/plugins
+
 # Proxy Configuration
 # Optional file with one proxy per line (http://user:pass@host:port or socks5://host:port),
 # rotated across yt-dlp fetches. Mount it into the container and point this at it.


### PR DESCRIPTION
Roughly a third of every file was comment, most of it narrating the line underneath. That is not documentation, it is noise between you and the logic.

**1683 comment lines down to 269.** Nothing else changed - 93 tests here, 47 across the plugin repos, all still pass.

What survived is the part the code genuinely cannot say - each one explains why something that looks removable is not:

- a plugin loading its own copy of the contract implements an unrelated \ISourceProvider\ and fails claiming \ISourceProvider\ cannot be cast to \ISourceProvider\
- a collectible load context is collected the moment nothing refers to it, taking the plugin's dependencies with it
- media URLs are signed for the address that asked for them, so the proxy has to travel with them
- a zip's central directory is written synchronously and Kestrel refuses that by default
- a regex from a plugin can backtrack badly enough to stall every request

Also in here: docs updated for plugins (\Plugins__*\ in the variables table, a Plugins section in configuration, platform table rows noting Spotify and TikTok need theirs), \COOKIES_PATH\ documented for the first time despite being referenced elsewhere, the Instagram section corrected - it claimed sessions were impossible while the table said \COOKIES_PATH\ works - and a \plugins\ volume in the compose file so they are not re-downloaded on every restart.