### PR TITLE
Cut the surviving comments to one line each

### DIFF
--- a/src/ArgonFetch.API/Controllers/StreamController.cs
+++ b/src/ArgonFetch.API/Controllers/StreamController.cs
@@ -57,10 +57,8 @@ namespace ArgonFetch.API.Controllers
             CancellationToken cancellationToken,
             [FromQuery] string? jobId = null)
         {
-            // Closing a zip entry writes its data descriptor, and closing the archive writes the
-            // central directory - both synchronously, with no async path offered for either, so
-            // Kestrel's default refusal truncates every archive. Allowed for this response alone;
-            // the bytes of the media itself still go out asynchronously.
+            // ZipArchive writes its central directory synchronously and Kestrel refuses that,
+            // which truncated every archive. The media itself still goes out asynchronously.
             var bodyControl = HttpContext.Features.Get<IHttpBodyControlFeature>();
 
             if (bodyControl is not null)

--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -52,10 +52,6 @@ builder.Services.AddEndpointsApiExplorer();
 #endregion
 
 #region External Services Configuration
-// Register YoutubeDL
-// Search and metadata only. Its streaming endpoints need a PoToken and answer 403 to IPs
-// that look like VPNs, which is exactly what a rotated proxy looks like; yt-dlp fetches the
-// media instead, as it always has.
 builder.Services.AddScoped(sp =>
 {
     var toolPaths = sp.GetRequiredService<ArgonFetch.Application.Services.IToolPaths>();
@@ -84,7 +80,7 @@ builder.Services.AddSingleton<ArgonFetch.Application.Services.IMediaHttpClients,
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IMaintenanceState, ArgonFetch.Application.Services.MaintenanceState>();
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IArchiveProgressTracker, ArgonFetch.Application.Services.ArchiveProgressTracker>();
 
-// Optional proxy list (one proxy per line) rotated across yt-dlp fetches; no file means direct fetches.
+// One proxy per line, rotated across fetches. No file means direct.
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IProxyPool>(sp =>
     new ArgonFetch.Application.Services.ProxyPool(
         ArgonFetch.Application.Services.ProxyPool.ReadList(builder.Configuration["PROXY_LIST_PATH"])));
@@ -93,7 +89,6 @@ builder.Services.AddSingleton<ArgonFetch.Application.Services.IProxyPool>(sp =>
 #region Validation
 builder.Services.AddFluentValidationAutoValidation();
 #region Plugins
-// Read as desired state: what the configuration lists is installed, what it does not is removed.
 var pluginOptions = builder.Configuration
     .GetSection(ArgonFetch.Application.Plugins.PluginOptions.SectionName)
     .Get<ArgonFetch.Application.Plugins.PluginOptions>() ?? new ArgonFetch.Application.Plugins.PluginOptions();

--- a/src/ArgonFetch.Abstractions/IProviderContext.cs
+++ b/src/ArgonFetch.Abstractions/IProviderContext.cs
@@ -5,14 +5,7 @@ namespace ArgonFetch.Abstractions
 {
     public interface IProviderContext
     {
-        /// <summary>
-        /// A client for talking to the source.
-        /// </summary>
-        /// <param name="rotateProxy">
-        /// Whether to go through the next proxy in the pool. Sources that count requests per
-        /// address want this; one that hands out an address signed for the caller does not,
-        /// because the download that follows has to come from the same place.
-        /// </param>
+        // rotateProxy: leave off for a source that signs an address for whoever asked.
         HttpClient CreateHttpClient(bool rotateProxy = true);
 
         IMemoryCache Cache { get; }

--- a/src/ArgonFetch.Abstractions/ISourceProvider.cs
+++ b/src/ArgonFetch.Abstractions/ISourceProvider.cs
@@ -4,20 +4,7 @@ namespace ArgonFetch.Abstractions
     {
         string Id { get; }
 
-        /// <summary>
-        /// Which links this provider wants, as regular expressions matched against the whole URL.
-        /// <para>
-        /// Declared rather than decided in code so the host can do the matching: it compiles each
-        /// one once instead of on every request, applies a time limit so a pattern that backtracks
-        /// badly cannot hang a download, and can say plainly which plugin claimed what. It also
-        /// means the usual plugin writes one line here and no matching code at all.
-        /// </para>
-        /// <para>
-        /// Matched without regard to case. A pattern that does not compile is skipped with a line
-        /// in the log rather than taking the plugin down with it.
-        /// </para>
-        /// </summary>
-        /// <example><c>[@"^https?://([\w-]+\.)*spotify\.com/"]</c></example>
+        // Matched case-insensitively against the whole URL. One that will not compile is skipped.
         IReadOnlyList<string> UrlPatterns { get; }
 
         bool CanHandle(Uri url) => true;

--- a/src/ArgonFetch.Application/Interfaces/IAcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Application/Interfaces/IAcceleratedDownloadService.cs
@@ -4,10 +4,7 @@ namespace ArgonFetch.Application.Interfaces
 {
     public interface IAcceleratedDownloadService
     {
-        /// <param name="range">
-        /// Window of the resource to write, or null for all of it. Set when a client is
-        /// seeking or resuming, in which case only these bytes may reach the output.
-        /// </param>
+        /// <param name="range">Window to write, or null for all of it.</param>
         Task StreamWithAccelerationAsync(
             string url,
             Stream outputStream,

--- a/src/ArgonFetch.Application/Plugins/PluginLoadContext.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginLoadContext.cs
@@ -3,22 +3,9 @@ using System.Runtime.Loader;
 
 namespace ArgonFetch.Application.Plugins
 {
-    /// <summary>
-    /// One plugin's own corner of the process.
-    /// <para>
-    /// A plugin brings its own dependencies, and two plugins will eventually bring different
-    /// versions of the same one. Each gets its own context so that stays their problem rather
-    /// than becoming a version conflict nobody can resolve.
-    /// </para>
-    /// <para>
-    /// The contract is the exception, and it has to be. Types have identity per context, so a
-    /// plugin loading its own copy of ArgonFetch.Abstractions would implement an
-    /// <c>ISourceProvider</c> unrelated to the one the host is looking for - and say so with a
-    /// message claiming ISourceProvider cannot be cast to ISourceProvider. It is deliberately
-    /// resolved from the host instead, which is why a plugin references the package without
-    /// shipping it.
-    /// </para>
-    /// </summary>
+    // Each plugin loads privately so its dependency versions stay its own problem. The
+    // contract is the exception: a plugin using its own copy gets a different type, and the
+    // cast fails claiming ISourceProvider cannot be cast to ISourceProvider.
     internal sealed class PluginLoadContext : AssemblyLoadContext
     {
         private static readonly string[] Shared =
@@ -32,7 +19,6 @@ namespace ArgonFetch.Application.Plugins
         private readonly AssemblyDependencyResolver _resolver;
 
         public PluginLoadContext(string pluginPath)
-            // Collectible so a plugin can be unloaded; without it, replacing one means a restart.
             : base(name: Path.GetFileNameWithoutExtension(pluginPath), isCollectible: true)
         {
             _resolver = new AssemblyDependencyResolver(pluginPath);
@@ -40,8 +26,7 @@ namespace ArgonFetch.Application.Plugins
 
         protected override Assembly? Load(AssemblyName assemblyName)
         {
-            // Null hands the request back to the default context, which is where the host's own
-            // copy lives. Anything else the plugin brought is loaded privately below.
+            // Null defers to the default context, where the host keeps its copy.
             if (Shared.Contains(assemblyName.Name, StringComparer.OrdinalIgnoreCase))
                 return null;
 

--- a/src/ArgonFetch.Application/Plugins/PluginLoader.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginLoader.cs
@@ -12,16 +12,8 @@ namespace ArgonFetch.Application.Plugins
         IReadOnlyList<ISourceProvider> Providers,
         IReadOnlyList<IFetchOptionsHook> Hooks)
     {
-        /// <summary>
-        /// The context this plugin's assemblies live in, held only so that it keeps living.
-        /// <para>
-        /// A collectible context is collected once nothing refers to it, and unloading takes the
-        /// plugin's own dependencies with it - which does not show up until the plugin first
-        /// reaches for one and is told the context is already unloaded. The providers above are
-        /// not enough to keep it: they are instances, and an instance does not root the context
-        /// its type was loaded into.
-        /// </para>
-        /// </summary>
+        // Held only to keep it alive: a collectible context is collected once nothing refers to
+        // it, taking the plugin's dependencies with it. Instances do not root it.
         internal AssemblyLoadContext? Context { get; init; }
     }
 

--- a/src/ArgonFetch.Application/Plugins/PluginOptions.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginOptions.cs
@@ -1,29 +1,13 @@
 namespace ArgonFetch.Application.Plugins
 {
-    /// <summary>
-    /// Which plugins an operator wants, and where to get them.
-    /// <para>
-    /// Read as desired state rather than as instructions: what is listed is installed, what is
-    /// not is removed. A list that says what should be true is one you can read and know what
-    /// the machine is running; a list of things that were once installed is not.
-    /// </para>
-    /// </summary>
+    // Desired state: what is listed is installed, what is not is removed.
     public class PluginOptions
     {
         public const string SectionName = "Plugins";
 
         public List<string> Repositories { get; set; } = [];
 
-        /// <summary>
-        /// Plugins to have installed, as "id" for the newest compatible build or "id@1.2.0" to
-        /// pin one.
-        /// <para>
-        /// The order is also precedence: where two plugins both claim a link, the one listed
-        /// first wins. Settling it here rather than by a number each plugin declares for itself
-        /// keeps the decision with the person who chose the plugins - and avoids every author
-        /// deciding theirs is the important one.
-        /// </para>
-        /// </summary>
+        // "id", or "id@1.2.0" to pin. Order is precedence when two plugins claim one link.
         public List<string> Install { get; set; } = [];
 
         public string Path { get; set; } = "plugins";

--- a/src/ArgonFetch.Application/Plugins/ProviderRegistry.cs
+++ b/src/ArgonFetch.Application/Plugins/ProviderRegistry.cs
@@ -15,15 +15,7 @@ namespace ArgonFetch.Application.Plugins
 
     public class ProviderRegistry : IProviderRegistry
     {
-        /// <summary>
-        /// How long one pattern may spend deciding.
-        /// <para>
-        /// A pattern is written by whoever wrote the plugin, and one that backtracks badly can
-        /// take a very long time over a URL built to provoke it. Every request is matched against
-        /// every installed pattern, so without a limit here one careless plugin would be enough
-        /// to stall the whole application.
-        /// </para>
-        /// </summary>
+        // A plugin's pattern can backtrack badly enough to stall every request.
         private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(100);
 
         private readonly IReadOnlyList<Claim> _providers;
@@ -34,9 +26,7 @@ namespace ArgonFetch.Application.Plugins
             Plugins = plugins;
             _logger = logger;
 
-            // Configured order, which the loader preserved. Precedence belongs to whoever chose
-            // the plugins rather than to a number each plugin declares about itself - given the
-            // chance, every author decides theirs is the important one.
+            // Configured order is precedence, so the choice stays with whoever installed them.
             _providers = plugins
                 .SelectMany(plugin => plugin.Providers.Select(provider =>
                     new Claim(plugin.Id, provider, Compile(plugin.Id, provider, logger))))

--- a/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
@@ -38,8 +38,7 @@ namespace ArgonFetch.Application.Queries
         private readonly IProviderContextFactory _providerContexts;
         private readonly ILogger<GetMediaQueryHandler> _logger;
 
-        // The proxy the last extraction went through. Media URLs are signed for the IP that
-        // requested them, so it has to travel with them to the stream endpoint.
+        // Media URLs are signed for the IP that asked, so the proxy travels with them.
         private string? _fetchProxy;
 
         private MediaTags? _overrideTags;

--- a/src/ArgonFetch.Application/Queries/StreamArchiveQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamArchiveQuery.cs
@@ -104,9 +104,7 @@ namespace ArgonFetch.Application.Queries
 
             try
             {
-                // Async throughout: the central directory is written on dispose, and Kestrel
-                // refuses a synchronous write to a response body.
-                // leaveOpen: Kestrel owns that body and closes it itself.
+                // leaveOpen: Kestrel owns the response body.
                 await using var archive = await ZipArchive.CreateAsync(
                     request.Response.Body, ZipArchiveMode.Create, leaveOpen: true, entryNameEncoding: null);
 

--- a/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/StreamMediaQuery.cs
@@ -105,13 +105,8 @@ namespace ArgonFetch.Application.Queries
                         tags,
                         MediaFormats.ExtensionFor(passThroughMimeType) ?? (isAudio ? ".mp3" : ".mp4"));
 
-                    // This path copies the upstream bytes through unchanged, so the upstream
-                    // length is the response length and can be declared. Without it the client
-                    // gets no Content-Length and cannot show real download progress.
-                    //
-                    // Only declared when the probe returns a length: whatever is written must
-                    // match it exactly or Kestrel throws on response completion. Conversion is
-                    // handled in the branch above, where the output length is not knowable.
+                    // Declared only when the probe knows it: what is written must match exactly or Kestrel
+                    // throws. Without it the client cannot show progress.
                     var upstreamLength = await _acceleratedDownloadService.GetContentLengthAsync(
                         mediaUrl,
                         proxy,
@@ -138,8 +133,6 @@ namespace ArgonFetch.Application.Queries
                                 break;
 
                             case RangeRequest.Unsatisfiable:
-                                // Nothing of the resource lies in the asked-for window, so the
-                                // caller is told how long it actually is and given no body.
                                 request.Response.StatusCode = StatusCodes.Status416RangeNotSatisfiable;
                                 request.Response.Headers.ContentRange = $"bytes */{total}";
                                 request.Response.ContentLength = 0;

--- a/src/ArgonFetch.Application/Services/ByteRange.cs
+++ b/src/ArgonFetch.Application/Services/ByteRange.cs
@@ -15,14 +15,7 @@ namespace ArgonFetch.Application.Services
         Unsatisfiable
     }
 
-    /// <summary>
-    /// Reads the Range request header.
-    /// <para>
-    /// Only single ranges are honoured. Multipart responses exist in the specification and
-    /// almost nothing asks for them - players and download managers ask for one window at a
-    /// time - so a multi-range request is served whole rather than half-answered.
-    /// </para>
-    /// </summary>
+    // Single ranges only; a multi-range request is served whole rather than half-answered.
     public static class RangeHeader
     {
         public static RangeRequest Parse(string? header, long totalLength, out ByteRange range)

--- a/src/ArgonFetch.Application/Services/MediaHttpClients.cs
+++ b/src/ArgonFetch.Application/Services/MediaHttpClients.cs
@@ -8,15 +8,7 @@ namespace ArgonFetch.Application.Services
         HttpClient For(string? proxy);
     }
 
-    /// <summary>
-    /// Hands out the HTTP client a media URL has to be fetched with.
-    /// <para>
-    /// Media URLs are signed for the IP that requested them, so one extracted through a proxy
-    /// is only downloadable through that same proxy - fetching it directly answers 403. Each
-    /// proxy therefore gets its own client, kept for the process lifetime because a handler per
-    /// request exhausts sockets.
-    /// </para>
-    /// </summary>
+    // Media URLs are signed for the requesting IP, so each proxy keeps its own client.
     public class MediaHttpClients : IMediaHttpClients
     {
         private readonly ConcurrentDictionary<string, HttpClient> _proxiedClients = new();

--- a/src/ArgonFetch.Application/Services/MediaTags.cs
+++ b/src/ArgonFetch.Application/Services/MediaTags.cs
@@ -12,8 +12,7 @@ namespace ArgonFetch.Application.Services
 
     public static class MediaFileName
     {
-        // Characters Windows refuses outright, plus the separators that would turn a name into a
-        // path. Trimmed rather than replaced with a marker: nobody wants "AC_DC" for "AC/DC".
+        // Trimmed rather than substituted: nobody wants "AC_DC" for "AC/DC".
         private static readonly char[] Invalid = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
 
         private const int MaxStemLength = 120;
@@ -70,7 +69,7 @@ namespace ArgonFetch.Application.Services
             if (trimmed.Length > MaxStemLength)
                 trimmed = trimmed[..MaxStemLength].TrimEnd();
 
-            // A trailing dot or space is legal in the header and unusable as a Windows filename.
+            // Legal in the header, unusable as a Windows filename.
             return trimmed.TrimEnd('.', ' ');
         }
 

--- a/src/ArgonFetch.Application/Services/MediaUrlCacheService.cs
+++ b/src/ArgonFetch.Application/Services/MediaUrlCacheService.cs
@@ -86,8 +86,7 @@ namespace ArgonFetch.Application.Services
                 Url = url,
                 IsAudio = isAudio,
                 MimeType = mimeType,
-                // Media URLs are signed for the IP that requested them, so the download has to
-                // leave through the same proxy the extraction did or the source answers 403.
+                // Signed for the requesting IP, so the download must leave through the same proxy.
                 Proxy = proxy,
                 Tags = tags ?? MediaTags.None,
                 CachedAt = DateTime.UtcNow

--- a/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/AcceleratedDownloadService.cs
@@ -10,9 +10,7 @@ namespace ArgonFetch.Infrastructure.Services
         private readonly IMediaHttpClients _mediaHttpClients;
         private readonly ILogger<AcceleratedDownloadService> _logger;
         private const int MIN_CHUNK_SIZE = 2 * 1024 * 1024; // 2MB chunks
-        // Chunk size is capped so the sliding window below stays bounded. Without a cap it
-        // scales with the file, and the window along with it - a 2GB download would hold
-        // roughly 1GB in memory.
+        // Capped so the window below stays bounded rather than scaling with the file.
         private const int MAX_CHUNK_SIZE = 8 * 1024 * 1024; // 8MB chunks
         private const int MAX_PARALLEL_CONNECTIONS = 8; // Maximum parallel connections
 
@@ -90,9 +88,7 @@ namespace ArgonFetch.Infrastructure.Services
                 return;
             }
 
-            // Serving a window rather than the file: the caller is seeking or resuming, and
-            // only the requested bytes may be written or the response will not line up with
-            // the Content-Range it announced.
+            // Only the requested bytes, or the response will not match its Content-Range.
             var window = range ?? new ByteRange(0, contentLength.Value - 1);
 
             _logger.LogInformation("Starting accelerated download with {Connections} connections for {Size} bytes",
@@ -155,8 +151,7 @@ namespace ArgonFetch.Infrastructure.Services
             var chunkSize = Math.Clamp(contentLength / (MAX_PARALLEL_CONNECTIONS * 2), MIN_CHUNK_SIZE, MAX_CHUNK_SIZE);
             var chunks = new List<(long start, long end)>();
 
-            // Chunks are offsets into the resource, not into the window, so a request for the
-            // tail of a file still asks the source for the right bytes.
+            // Offsets into the resource, not the window.
             for (var i = window.From; i <= window.To; i += chunkSize)
             {
                 var end = Math.Min(i + chunkSize - 1, window.To);
@@ -166,11 +161,8 @@ namespace ArgonFetch.Infrastructure.Services
             _logger.LogInformation("Downloading {ChunkCount} chunks of ~{ChunkSizeMb} MB each",
                 chunks.Count, chunkSize / 1024 / 1024);
 
-            // Sliding window: at most MAX_PARALLEL_CONNECTIONS chunks are downloading or
-            // waiting to be written at any moment, so peak memory is bounded by the window
-            // rather than by the size of the file. Chunks are written in order and their
-            // buffers released as soon as they reach the output stream, which also means the
-            // consumer starts receiving data before the last chunk has arrived.
+            // Sliding window: peak memory is bounded by the window, not the file size, and the
+            // consumer starts receiving before the last chunk arrives.
             var inFlight = new Queue<Task<byte[]>>(MAX_PARALLEL_CONNECTIONS);
             var nextToStart = 0;
             var totalBytesDownloaded = 0L;

--- a/src/ArgonFetch.Infrastructure/Services/FfmpegStreamingService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/FfmpegStreamingService.cs
@@ -142,8 +142,7 @@ namespace ArgonFetch.Infrastructure.Services
             if (isAudio)
             {
                 processStartInfo.ArgumentList.Add("-vn");        // Disable video
-                // ID3v2.3 rather than the default 2.4: a fair number of players and Windows
-                // Explorer read tags only from the older revision.
+                // 2.3, not the default 2.4: many players and Explorer only read the older revision.
                 processStartInfo.ArgumentList.Add("-id3v2_version");
                 processStartInfo.ArgumentList.Add("3");
                 processStartInfo.ArgumentList.Add("-c:a");
@@ -282,10 +281,7 @@ namespace ArgonFetch.Infrastructure.Services
             }
         }
 
-        /// <summary>
-        /// Routes the input that follows through the proxy the URL was extracted with. Media
-        /// URLs are signed for the requesting IP, so fetching one from anywhere else is a 403.
-        /// </summary>
+        // Media URLs are signed for the requesting IP, so this must match the extraction.
         private static void AddProxy(ProcessStartInfo processStartInfo, string? proxy)
         {
             if (string.IsNullOrWhiteSpace(proxy))

--- a/src/ArgonFetch.Infrastructure/Services/MediaToolsService.cs
+++ b/src/ArgonFetch.Infrastructure/Services/MediaToolsService.cs
@@ -49,8 +49,7 @@ namespace ArgonFetch.Infrastructure.Services
                     }
                 }
 
-                // One window covers both steps: whether yt-dlp is being written for the first
-                // time or replaced by --update, it is unusable while it happens.
+                // yt-dlp is unusable while it is written, whether first install or --update.
                 using (_maintenance.Begin(File.Exists(_paths.YtDlpPath) ? "Updating yt-dlp" : "Downloading yt-dlp"))
                 {
                     if (!File.Exists(_paths.YtDlpPath))

--- a/src/ArgonFetch.Tests/ArchiveNamingTests.cs
+++ b/src/ArgonFetch.Tests/ArchiveNamingTests.cs
@@ -25,8 +25,7 @@ namespace ArgonFetch.Tests
         [Fact]
         public void Unique_TreatsNamesDifferingOnlyInCaseAsTheSame()
         {
-            // Windows and macOS would, so an archive that relies on the difference unpacks to
-            // fewer files than it holds.
+            // Windows and macOS would collide these, unpacking fewer files than the zip holds.
             var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             StreamArchiveQueryHandler.Unique("Song.webm", used);


### PR DESCRIPTION
The last pass kept the right comments but left them at the length they were written - three-paragraph summaries where a sentence does the same work. A comment that takes longer to read than the code it sits above is still in the way, however true it is.

**269 comment lines down to 81.** 93 tests here, 47 across the plugin repos, all pass.

Each survivor is now a line or two saying only what the code cannot - a plugin's own copy of the contract is a different type; a collectible context is collected the moment nothing holds it; media URLs are signed for the address that asked. The reasoning behind them is in the history, which is where reasoning belongs.

Also removed a comment describing a YouTube Music client that no longer exists, left sitting above the yt-dlp registration where it described nothing.

Untagged \///\ blocks became \//\ - a doc comment with no tags in it is just a comment wearing the wrong prefix.