### PR TITLE
Stop a plugins directory the app cannot write from killing it

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Everything is set through environment variables, normally in the `.env` file nex
 | Variable | Required | Description |
 |---|---|---|
 | `CORS_ALLOWED_ORIGINS` | in production | Comma-separated origins allowed to call the API. Defaults to `http://localhost:4200`, and the app warns at startup if that default is still in use in production |
-| `ASPNETCORE_ENVIRONMENT` | no | `Production` by default. `Development` also enables the Swagger UI |
+| `ASPNETCORE_ENVIRONMENT` | no | Already `Production` when unset - set it only to run as `Development`, which enables the Swagger UI |
 | `TOOLS_PATH` | no | Where `yt-dlp` and `FFmpeg` are downloaded to. `/tools` in the image, which is the path the compose file mounts a volume on. Must be writable by the runtime user |
 | `PROXY_LIST_PATH` | no | File with one proxy per line, rotated across `yt-dlp` fetches so they do not all leave from the same IP. See [below](#proxy-rotation) |
 | `COOKIES_PATH` | no | Netscape-format cookies file exported from a signed-in browser, for sources that serve nothing to strangers. See [Platforms](/platforms#sites-that-need-an-account) |
@@ -17,7 +17,6 @@ Everything is set through environment variables, normally in the `.env` file nex
 A complete `.env` for a public deployment:
 
 ```ini
-ASPNETCORE_ENVIRONMENT=Production
 CORS_ALLOWED_ORIGINS=https://argonfetch.example.com
 
 Plugins__Repositories__0=https://raw.githubusercontent.com/ArgonFetch/ArgonFetchPlugins/repo/index.json

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -23,10 +23,13 @@ services:
       # yt-dlp and FFmpeg are fetched on boot instead of being baked into the image.
       # Keeping them here means a restart reuses them rather than downloading again.
       - tools:/tools
+      # Same for plugins.
+      - plugins:/plugins
     restart: unless-stopped
 
 volumes:
   tools:
+  plugins:
 ```
 
 ## 2. Create `.env` next to it
@@ -34,6 +37,12 @@ volumes:
 ```ini
 # Origins allowed to call the API. Set this to your own host in production.
 CORS_ALLOWED_ORIGINS=http://localhost:8080
+
+# Spotify and TikTok are plugins rather than built in. Leave these out and their links
+# will not resolve; everything yt-dlp handles works either way.
+Plugins__Repositories__0=https://raw.githubusercontent.com/ArgonFetch/ArgonFetchPlugins/repo/index.json
+Plugins__Install__0=spotify
+Plugins__Install__1=tiktok
 ```
 
 ## 3. Start it
@@ -66,11 +75,14 @@ ArgonFetch images are published to two registries - pick whichever suits your se
 | GitHub Container Registry | `ghcr.io/argonfetch/argonfetch:latest` |
 | Docker Hub | `docker.io/pianonic/argonfetch:latest` |
 
-## Mount `/tools`
+## Mount `/tools` and `/plugins`
 
-The compose file above mounts one volume, and it is not a database. `/tools` holds `yt-dlp`
-and `FFmpeg`. Keep it - without one, roughly 100MB is downloaded again every time the
-container starts.
+Neither volume is a database. `/tools` holds `yt-dlp` and `FFmpeg`; without it, roughly 100MB is
+downloaded again every time the container starts. `/plugins` holds whatever you named under
+`Plugins__Install__*`, for the same reason.
+
+Both are created inside the image and writable by the runtime user, so the paths need no
+configuration - only the volumes, if you would rather not re-download on every start.
 
 Nothing else is written anywhere. ArgonFetch keeps no record of what it has been asked to
 fetch, and no count of how often.

--- a/src/ArgonFetch.API/Dockerfile
+++ b/src/ArgonFetch.API/Dockerfile
@@ -17,6 +17,13 @@ ENV TOOLS_PATH=/tools
 RUN mkdir -p /tools && chown -R $APP_UID:0 /tools && chmod 0775 /tools
 VOLUME /tools
 
+# Plugins are downloaded on boot for the same reason, into a directory the runtime user can
+# write to. /app is owned by root, so the default relative path could not be created and the
+# container crash-looped before serving anything.
+ENV Plugins__Path=/plugins
+RUN mkdir -p /plugins && chown -R $APP_UID:0 /plugins && chmod 0775 /plugins
+VOLUME /plugins
+
 # The fetched FFmpeg is built against OpenSSL's own default paths, which are Debian's and do
 # not exist here, so every HTTPS input failed certificate verification. Pointing it at this
 # image's bundle fixes that; the CA data itself is already in the base image.

--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -153,14 +153,22 @@ var startupLogger = app.Services.GetRequiredService<ILogger<Program>>();
         ? pluginOptions.Path
         : Path.Combine(app.Environment.ContentRootPath, pluginOptions.Path);
 
-    await app.Services.GetRequiredService<ArgonFetch.Application.Plugins.PluginInstaller>()
-        .InstallAsync(pluginOptions, pluginRoot);
+    try
+    {
+        await app.Services.GetRequiredService<ArgonFetch.Application.Plugins.PluginInstaller>()
+            .InstallAsync(pluginOptions, pluginRoot);
 
-    var registry = app.Services.GetRequiredService<ArgonFetch.Application.Plugins.IProviderRegistry>();
+        var registry = app.Services.GetRequiredService<ArgonFetch.Application.Plugins.IProviderRegistry>();
 
-    startupLogger.LogInformation("Plugins: {Count} loaded{Names}",
-        registry.Plugins.Count,
-        registry.Plugins.Count == 0 ? string.Empty : " - " + string.Join(", ", registry.Plugins.Select(p => $"{p.Id} {p.Version}")));
+        startupLogger.LogInformation("Plugins: {Count} loaded{Names}",
+            registry.Plugins.Count,
+            registry.Plugins.Count == 0 ? string.Empty : " - " + string.Join(", ", registry.Plugins.Select(p => $"{p.Id} {p.Version}")));
+    }
+    catch (Exception ex)
+    {
+        // Sources a plugin would have added stop working; everything yt-dlp handles still does.
+        startupLogger.LogError(ex, "Plugins could not be prepared; continuing without them");
+    }
 }
 
 if (app.Environment.IsProduction() && corsUsesDevelopmentDefault)

--- a/src/ArgonFetch.Application/Plugins/PluginInstaller.cs
+++ b/src/ArgonFetch.Application/Plugins/PluginInstaller.cs
@@ -21,7 +21,17 @@ namespace ArgonFetch.Application.Plugins
 
         public async Task InstallAsync(PluginOptions options, string root, CancellationToken cancellationToken = default)
         {
-            Directory.CreateDirectory(root);
+            try
+            {
+                Directory.CreateDirectory(root);
+            }
+            catch (Exception ex)
+            {
+                // Nothing below can work, but a downloader that will not start is worse than one
+                // without plugins - and this threw before any of the guards further down.
+                _logger.LogError(ex, "Cannot use {Root} for plugins, so none will be installed", root);
+                return;
+            }
 
             var wanted = options.Install
                 .Select(Parse)

--- a/template.env
+++ b/template.env
@@ -1,6 +1,5 @@
 # Application Configuration
 APP_PORT=8080
-ASPNETCORE_ENVIRONMENT=Production
 
 # CORS Configuration
 # Comma-separated list of allowed origins
@@ -15,8 +14,6 @@ CORS_ALLOWED_ORIGINS=https://app.argonfetch.dev,https://docs.argonfetch.dev
 Plugins__Repositories__0=https://raw.githubusercontent.com/ArgonFetch/ArgonFetchPlugins/repo/index.json
 Plugins__Install__0=spotify
 Plugins__Install__1=tiktok
-# Where they are kept. Matches the volume the compose file mounts, so a restart reuses them.
-Plugins__Path=/plugins
 
 # Proxy Configuration
 # Optional file with one proxy per line (http://user:pass@host:port or socks5://host:port),


### PR DESCRIPTION
The container crash-looped on start:

\\\
Unhandled exception. System.UnauthorizedAccessException: Access to the path '/app/plugins' is denied.
argonfetch exited with code 139 (restarting)
\\\

Two things were wrong, and both are fixed.

**The path was never writable.** The default is relative to the content root, which in the image is \/app\ - owned by root, while the app runs as someone else. The Dockerfile already does \mkdir\ + \chown\ + \ENV\ for \/tools\; it now does the same for \/plugins\ and defaults \Plugins__Path\ to it. Nobody configures a path, and an existing \.env\ keeps working.

**And it was fatal.** \Directory.CreateDirectory\ sat above every guard meant to stop a plugin problem mattering, so the process died and the restart policy did it again. A downloader without plugins is worse than one with them; a downloader that will not start is worse than either.

## Verified in a container

| | |
|---|---|
| With the fix | installs both plugins, resolves a Spotify track (5 renditions) |
| \Plugins__Path\ pointed somewhere unwritable | logs \Cannot use ... for plugins\, stays up, serves everything yt-dlp handles |

## Also

**\ASPNETCORE_ENVIRONMENT\ removed from the sample \.env\ and the template.** .NET is already in Production when it is unset - confirmed by running the container without it and reading \nvironment\ back from \/api/App\. The docs were telling people to set something that was true before they started.

The self-hosting page mounts \/plugins\ alongside \/tools\ and names the two plugins in its \.env\, which it should have done when they stopped being built in.