### PR TITLE
Offer the fast video options and the slow ones together

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -574,9 +574,6 @@
       "StreamReferenceDto": {
         "type": "object",
         "properties": {
-          "urlType": {
-            "$ref": "#/components/schemas/UrlType"
-          },
           "renditions": {
             "type": "array",
             "items": {

--- a/src/ArgonFetch.Application/Dtos/StreamReferenceDto.cs
+++ b/src/ArgonFetch.Application/Dtos/StreamReferenceDto.cs
@@ -1,11 +1,9 @@
-﻿using ArgonFetch.Application.Enums;
-
-namespace ArgonFetch.Application.Dtos
+﻿namespace ArgonFetch.Application.Dtos
 {
     public class StreamReferenceDto
     {
-        public UrlType UrlType { get; set; }
-
+        // No UrlType beside this: one list holds renditions served by both endpoints, so only
+        // the per-rendition value can be right.
         public List<MediaRenditionDto> Renditions { get; set; } = [];
     }
 }

--- a/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
+++ b/src/ArgonFetch.Application/Queries/GetMediaQuery.cs
@@ -131,36 +131,41 @@ namespace ArgonFetch.Application.Queries
                     proxy: _fetchProxy,
                     tags: tags);
 
-                List<MediaRenditionDto> videoRenditions;
-                UrlType videoUrlType;
+                // Sent untouched: fast, declares a length, supports ranges. Sources stop
+                // offering these well below their best resolution.
+                var passThrough = _proxyUrlBuilder.BuildRenditions(
+                    RenditionPicker.PickVideo(PreMuxedSources(resultData.Formats), perContainer: true),
+                    _cacheService,
+                    isAudio: false,
+                    proxy: _fetchProxy,
+                    tags: tags);
 
-                if (HasValidUrls(combinedFormats))
-                {
-                    videoUrlType = UrlType.Media;
-                    videoRenditions = _proxyUrlBuilder.BuildRenditions(
-                        RenditionPicker.PickVideo(PreMuxedSources(resultData.Formats), perContainer: true),
-                        _cacheService,
-                        isAudio: false,
-                        proxy: _fetchProxy,
-                        tags: tags);
-                }
-                else
-                {
-                    videoUrlType = UrlType.Combined;
-                    videoRenditions = _combinedUrlBuilder.BuildCombinedRenditions(
-                        RenditionPicker.PickVideo(VideoOnlySources(resultData.Formats)),
-                        RenditionPicker.PickAudio(AudioSources(resultData.Formats), count: 1).FirstOrDefault(),
-                        _cacheService,
-                        _fetchProxy,
-                        tags);
-                }
+                // The higher steps exist only as separate tracks, muxed on the way out: slower,
+                // and no length to declare. Both are offered so the choice is the caller's.
+                var muxed = _combinedUrlBuilder.BuildCombinedRenditions(
+                    RenditionPicker.PickVideo(VideoOnlySources(resultData.Formats)),
+                    RenditionPicker.PickAudio(AudioSources(resultData.Formats), count: 1).FirstOrDefault(),
+                    _cacheService,
+                    _fetchProxy,
+                    tags);
+
+                // A resolution already available untouched would be the same picture, slower.
+                var untouchedHeights = passThrough
+                    .Select(rendition => rendition.Height)
+                    .Where(height => height is not null)
+                    .ToHashSet();
+
+                var videoRenditions = passThrough
+                    .Concat(muxed.Where(rendition => !untouchedHeights.Contains(rendition.Height)))
+                    .OrderByDescending(rendition => rendition.Height ?? 0)
+                    .ToList();
 
                 combinedReferences = videoRenditions.Count > 0
-                    ? new StreamReferenceDto { UrlType = videoUrlType, Renditions = videoRenditions }
+                    ? new StreamReferenceDto { Renditions = videoRenditions }
                     : null;
 
                 audioReferences = audioRenditions.Count > 0
-                    ? new StreamReferenceDto { UrlType = UrlType.Media, Renditions = audioRenditions }
+                    ? new StreamReferenceDto { Renditions = audioRenditions }
                     : null;
 
                 return new ResourceInformationDto
@@ -308,7 +313,7 @@ namespace ArgonFetch.Application.Queries
 
             return renditions.Count == 0
                 ? null
-                : new StreamReferenceDto { UrlType = UrlType.Media, Renditions = renditions };
+                : new StreamReferenceDto { Renditions = renditions };
         }
 
         private async Task<ProbeResult?> ProbeAsync(Uri url, CancellationToken cancellationToken)

--- a/src/ArgonFetch.Frontend/src/app/api/model/streamReferenceDto.ts
+++ b/src/ArgonFetch.Frontend/src/app/api/model/streamReferenceDto.ts
@@ -8,14 +8,9 @@
  * Do not edit the class manually.
  */
 import { MediaRenditionDto } from './mediaRenditionDto';
-import { UrlType } from './urlType';
 
 
 export interface StreamReferenceDto { 
-    urlType?: UrlType;
     renditions?: Array<MediaRenditionDto> | null;
 }
-export namespace StreamReferenceDto {
-}
-
 

--- a/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.html
+++ b/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.html
@@ -48,11 +48,17 @@
     <ng-template #videoMenu>
       <div class="dropdown-menu" cdkMenu animate.enter="menu-enter" animate.leave="menu-leave">
         @for (rendition of videoRenditions(); track rendition.key + (rendition.convertTo ?? '')) {
+          <!-- A muxed rendition is quality the source only offers as separate video and audio.
+               Its size is a prediction rather than a length the server can declare, and it
+               arrives slower, so it is marked whether or not a size came with it. -->
           <button type="button" class="menu-item" cdkMenuItem
             (cdkMenuItemTriggered)="onDownloadRendition(rendition)">
             <span class="menu-item-label">
               {{ rendition.label }}
               <span class="menu-item-type">{{ typeOf(rendition) }}</span>
+              @if (isMuxed(rendition)) {
+                <span class="menu-item-note">slower</span>
+              }
             </span>
             @if (sizeOf(rendition)) {
               <span class="menu-item-size">{{ sizeOf(rendition) }}</span>

--- a/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.scss
+++ b/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.scss
@@ -208,6 +208,15 @@
   border-top: 1px solid var(--border);
 }
 
+/* Fast and muxed steps interleave by resolution, so the warning rides on the row it belongs
+   to rather than trying to divide the menu into two halves that do not exist. */
+.menu-item-note {
+  margin-left: 0.4rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  opacity: 0.65;
+}
+
 /* Not a button: there is nothing to press when a source offers no renditions, and a menu
    item that looks pressable but does nothing is worse than one that plainly cannot be. */
 .menu-item--empty {

--- a/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.ts
+++ b/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.ts
@@ -6,7 +6,7 @@ import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { MediaRenditionDto, ResourceInformationDto } from '../../api';
 import { HttpClientModule } from '@angular/common/http';
 import { MediaDownloadService } from '../../services/media-download.service';
-import { ResourceUrlService } from '../../services/resource-url.service';
+import { ResourceUrlService, UrlType } from '../../services/resource-url.service';
 import { DownloadProgressComponent } from '../../download-progress/download-progress.component';
 
 @Component({
@@ -49,6 +49,15 @@ export class SingleSongContainerComponent {
    */
   typeOf(rendition: MediaRenditionDto): string {
     return (rendition.fileExtension || '').replace('.', '').toUpperCase();
+  }
+
+  /**
+   * Whether a rendition has to be muxed on the way out. Those are the higher resolutions a
+   * source only offers as separate video and audio: worth having, but slower to arrive and
+   * with no size to show beforehand, so the menu says as much before someone picks one.
+   */
+  isMuxed(rendition: MediaRenditionDto): boolean {
+    return rendition.urlType === UrlType.Combined;
   }
 
   /** Size label for a rendition, e.g. "3.3 MB". Empty when the source does not report one. */


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [x] UI/UX improvement

## Description

Sources serve two kinds of video, and ArgonFetch only ever offered one of them —
`GetMediaQuery` took either the pre-muxed branch or the muxed branch, never both.

Formats that already carry both tracks are sent untouched: fast, with a declared length and
range support. Sources usually stop offering those well below their best resolution. The higher
steps exist only as separate video and audio, muxed on the way out: slower, no length, no ranges.

Picking one branch decided for the person:

- pre-muxed branch → quality capped at whatever the source happened to pre-mux
- muxed branch → **every** download slow with no progress, including a 360p sitting right there

Both are built now and merged into one list by resolution. A muxed step whose resolution is
already available untouched is dropped — the same picture, slower, for nothing.

### Before and after, same video

`https://www.youtube.com/watch?v=dQw4w9WgXcQ`

| Before | After |
|---|---|
| 2160p muxed | 2160p muxed *(slower)* |
| 1080p muxed | 1080p muxed *(slower)* |
| 360p muxed | **360p fast — 11 MB** |
| 144p muxed | 144p muxed *(slower)* |

The 360p now streams straight through instead of being muxed for no reason.

### The menu says which is which

A muxed rendition **does** report a size — the two halves summed — so absence of a size cannot
be the signal. The mark comes from the rendition's own `urlType`. Fast and muxed interleave by
resolution, so it rides on each row rather than trying to split the menu into two halves that do
not exist.

## Testing

`dotnet build` clean, `dotnet test` 118 passing, `bun run build` clean.

Measured both endpoints on a real rendition:

| | fast (360p, pass-through) | muxed (2160p) |
|---|---|---|
| Status | `206 Partial Content` | `200 OK` |
| `Content-Length` | 1048576 | none |
| `Accept-Ranges` | bytes | none |
| `Content-Range` | `0-1048575/11829048` | none |

So the fast options are seekable, resumable and drive a real percentage bar; the muxed ones
genuinely cannot be, which is what the indeterminate bar has always been telling us.

Across sources, with no duplicate resolutions in any list:

- **YouTube 4K** — 2160p/1080p/144p muxed, 360p fast
- **The BBB recording from the report** — 720p/144p muxed, 360p fast
- **TikTok** — its single pass-through rendition, unchanged

One caveat worth recording: **YouTube does not return the same format set every time.** Two
fetches of the same video minutes apart gave a pre-muxed 360p once and none the next, so whether
a fast option appears can vary per request. That is the source's behaviour, not this change.

**Not verified in the container.** Docker Desktop's daemon stopped partway through, so this was
verified with a local `bun run build` and the API running directly instead. Worth a container
check before release.

## Impact

**Breaking:** `StreamReferenceDto.urlType` is removed. One list can now hold renditions served by
both endpoints, so a single value for the whole reference could only be wrong. Each rendition has
carried its own `urlType` all along, and that is what the frontend reads — nothing in the repo
used the parent. Schema and generated client are regenerated here.

## Issue related to PR
- Resolves #233

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.