### PR TITLE
Measure a muxed download against the size already predicted for it

### DIFF
--- a/src/ArgonFetch.Frontend/src/app/content-results/playlist-container/playlist-container.component.ts
+++ b/src/ArgonFetch.Frontend/src/app/content-results/playlist-container/playlist-container.component.ts
@@ -122,7 +122,10 @@ export class PlaylistContainerComponent {
 
       const extension = audio?.renditions?.[0]?.fileExtension || '';
 
-      await this.downloads.download(url, `${media?.title || song.title}${extension}`);
+      await this.downloads.download(
+        url,
+        `${media?.title || song.title}${extension}`,
+        audio?.renditions?.[0]?.fileSizeBytes);
     } catch (error: any) {
       // A Spotify track is played from somewhere else, and the odd remix or regional
       // release has no counterpart to find. That is a different thing from the source

--- a/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.ts
+++ b/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.ts
@@ -80,7 +80,7 @@ export class SingleSongContainerComponent {
     const title = this.resourceInformation.mediaItems?.[0]?.title || 'download';
     const extension = rendition.fileExtension || '';
 
-    await this.downloads.download(url, `${title}${extension}`);
+    await this.downloads.download(url, `${title}${extension}`, rendition.fileSizeBytes);
   }
 
   hasCombinedUrls(): boolean {

--- a/src/ArgonFetch.Frontend/src/app/download-progress/download-progress.component.html
+++ b/src/ArgonFetch.Frontend/src/app/download-progress/download-progress.component.html
@@ -8,11 +8,11 @@
         }
         @if (downloadedMB()) {
           <span class="download-size">
-            {{ downloadedMB() }}@if (hasKnownTotal()) { / {{ totalMB() }}} MB
+            {{ downloadedMB() }}@if (hasKnownTotal()) { / @if (isEstimatedTotal()) {~}{{ totalMB() }}} MB
           </span>
         }
         @if (hasKnownTotal()) {
-          <span class="download-percentage">{{ progress() }}%</span>
+          <span class="download-percentage">@if (isEstimatedTotal()) {~}{{ progress() }}%</span>
         }
       </div>
     </div>
@@ -20,8 +20,8 @@
       @if (hasKnownTotal()) {
         <div class="progress-bar" [style.width.%]="progress()" [style.max-width]="'100%'"></div>
       } @else {
-        <!-- The server cannot declare a length for muxed streams, so show motion
-             rather than a number that would be invented. -->
+        <!-- Neither the response nor the rendition offered a size, so show motion rather
+             than a number that would be invented. -->
         <div class="progress-bar progress-bar--indeterminate"></div>
       }
     </div>

--- a/src/ArgonFetch.Frontend/src/app/download-progress/download-progress.component.ts
+++ b/src/ArgonFetch.Frontend/src/app/download-progress/download-progress.component.ts
@@ -28,4 +28,5 @@ export class DownloadProgressComponent {
   readonly totalMB = this.downloads.totalMB;
   readonly downloadedMB = this.downloads.downloadedMB;
   readonly hasKnownTotal = this.downloads.hasKnownTotal;
+  readonly isEstimatedTotal = this.downloads.isEstimatedTotal;
 }

--- a/src/ArgonFetch.Frontend/src/app/services/media-download.service.ts
+++ b/src/ArgonFetch.Frontend/src/app/services/media-download.service.ts
@@ -22,8 +22,14 @@ export class MediaDownloadService {
   readonly downloadedMB = signal('');
   readonly hasKnownTotal = signal(false);
 
+  // Whether the total came from the rendition rather than the response. A muxed stream sends no
+  // length, but the server did predict one from the two tracks it is about to combine, so the
+  // bar can be honest about roughly how far along it is instead of saying nothing at all.
+  readonly isEstimatedTotal = signal(false);
+
   private lastTime = 0;
   private lastBytes = 0;
+  private expectedBytes: number | null = null;
 
   constructor() {
     // A transfer lives in this page, so leaving takes it with you - reload included, which is
@@ -45,12 +51,17 @@ export class MediaDownloadService {
     return this.isDownloading();
   }
 
-  download(url: string, fileName: string): Promise<void> {
+  /**
+   * @param expectedBytes Size the server predicted for this rendition, used only when the
+   * response declares no length of its own. A prediction, so the bar it drives is one too.
+   */
+  download(url: string, fileName: string, expectedBytes?: number | null): Promise<void> {
     return new Promise<void>(resolve => {
       this.reset();
       this.isDownloading.set(true);
       this.fileName.set(fileName);
       this.downloadedMB.set('0');
+      this.expectedBytes = expectedBytes && expectedBytes > 0 ? expectedBytes : null;
       this.lastTime = Date.now();
 
       // Errors arrive on the error callback rather than as a thrown exception; subscribe()
@@ -78,14 +89,22 @@ export class MediaDownloadService {
   }
 
   private report(loaded: number, total?: number) {
-    // A percentage is only reported when the real transfer size is known. The combined endpoint
-    // muxes on the fly and genuinely cannot send a length; there the bar runs indeterminate and
-    // the byte counter carries the information.
-    this.hasKnownTotal.set(!!total);
+    // The combined endpoint muxes on the fly and cannot declare a length, so fall back to the
+    // size the server predicted for the rendition. Only when neither exists does the bar go
+    // indeterminate and leave the byte counter to carry the information.
+    const estimated = !total && this.expectedBytes !== null;
+    const denominator = total ?? this.expectedBytes;
 
-    if (total) {
-      this.progress.set(Math.min(100, Math.max(0, Math.round((loaded / total) * 100))));
-      this.totalMB.set((total / 1024 / 1024).toFixed(1));
+    this.hasKnownTotal.set(!!denominator);
+    this.isEstimatedTotal.set(estimated);
+
+    if (denominator) {
+      const percent = Math.round((loaded / denominator) * 100);
+
+      // An estimate stops one short rather than sitting at 100% while bytes still arrive: a
+      // mux weighs a little more than the two tracks going into it, so it will overshoot.
+      this.progress.set(Math.max(0, Math.min(estimated ? 99 : 100, percent)));
+      this.totalMB.set((denominator / 1024 / 1024).toFixed(1));
     } else {
       this.progress.set(0);
       this.totalMB.set('');
@@ -124,6 +143,8 @@ export class MediaDownloadService {
     this.totalMB.set('');
     this.downloadedMB.set('');
     this.hasKnownTotal.set(false);
+    this.isEstimatedTotal.set(false);
+    this.expectedBytes = null;
     this.lastBytes = 0;
   }
 


### PR DESCRIPTION
## Type of Change
- [x] UI/UX improvement

## Description

A muxed download showed an indeterminate bar and a byte counter and nothing else — the case
reported as `147.1 KB/s   1.3 MB` with no way to tell a tenth done from nearly finished.

The bar was right to refuse: `/api/Stream/Combined/{key}` muxes on the fly and cannot declare a
`Content-Length`, so `event.total` is undefined and inventing a percentage from nothing would be
a lie.

But the size was already known. `BuildCombinedRenditions` predicts one by summing the two tracks
it is about to combine, and it reaches the client — the menu shows `232 MB` beside the 4K option
*before you click it*. The download then threw that number away.

It is now the denominator when the response declares none, marked `~` so it reads as a
prediction rather than a measurement.

Two deliberate limits:

- **The prediction stays out of `Content-Length`.** A mux weighs slightly more than its inputs,
  so declaring the sum would misdescribe the body and break the transfer.
- **An estimated bar stops at 99%**, for the same reason — it would otherwise sit at 100% while
  bytes still arrived.

A rendition with no predicted size still gets the indeterminate bar; nothing is invented.

## Testing

`bun run build` clean.

There is no frontend test suite, so this was driven in a real browser against the running app —
API on 5114, dev server on 4200 — sampling the DOM through a muxed download of the 4K rendition:

| | stats | bar width | indeterminate |
|---|---|---|---|
| before first progress event | `0 MB` | — | **true** |
| | `30 B/s 0.9 / ~232.5 MB ~0%` | 0% | false |
| | `2.7 MB/s 5.1 / ~232.5 MB ~2%` | 2% | false |
| | `2.7 MB/s 6.9 / ~232.5 MB ~3%` | 3% | false |
| | `355.8 KB/s 11.9 / ~232.5 MB ~5%` | 5% | false |
| | `5.1 MB/s 17.3 / ~232.5 MB ~7%` | 7% | false |

So the bar advances against the prediction, the `~` marks it, and the indeterminate state still
covers the moment before any size is known.

The pass-through path is untouched and still exact: a 3.3 MB audio rendition, which does send a
`Content-Length`, finished before the first 500 ms sample. `~` renders only when
`isEstimatedTotal()` is true, which requires `event.total` to be absent.

Incidentally, that 4K mux reached **5.1 MB/s** here — so the `147 KB/s` in the report was that
particular source being slow, not muxing being inherently slow.

## Impact

Frontend only. No API change, so the schema and generated client are untouched.

Overlaps `single-song-container.component.ts` with #234, which is still open — whichever lands
second needs a small rebase.

## Issue related to PR
- Resolves #235

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.