### PR TITLE
Build and test a pull request before it can be merged

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A new push supersedes the run already going for that branch.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore ArgonFetch.slnx
+
+      # Warnings are errors for nullable (Directory.Build.props), so this is not only a
+      # compile check.
+      - name: Build
+        run: dotnet build ArgonFetch.slnx --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test ArgonFetch.slnx --no-build --configuration Release --verbosity normal
+
+  image:
+    name: Build image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Built and thrown away. The point is that it builds at all: the Dockerfile keeps its own
+      # list of projects to copy and installs the frontend with --frozen-lockfile, so a deleted
+      # project or a lockfile behind package.json breaks the image while every local check still
+      # passes. Both reached a published release that way (#219, #214).
+      #
+      # One architecture, because neither failure was architecture-specific and the release
+      # publish is where multi-arch belongs.
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./src/ArgonFetch.API/Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description

Nothing ran on a pull request — no build, no tests, no image. The only workflows were the
release publish, the drafter, an issue guard and a manual version bump.

That is how v1.6.0 shipped with no image. Two blockers reached a published release because every
local check passed:

- **#219** — the Dockerfile still copied `ArgonFetch.Domain` after #213 deleted the project.
  `dotnet build`, `dotnet test` and running the API never touch the Dockerfile's hand-maintained
  `COPY` list.
- **#214** — `bun.lock` was missing `lucide`, and the Dockerfile installs with
  `--frozen-lockfile`. Only a clean install hits that; nobody with warm `node_modules` does one.

The release publish was the first thing to try either, and by then the tag was public.

Adds a `CI` workflow on `pull_request` and pushes to `main`:

**test** — `dotnet restore` / `build` / `test` in Release. This is the first time `dotnet test`
has run anywhere but a developer's machine. `Directory.Build.props` makes nullable warnings
errors, so the build is more than a compile check.

**image** — `docker build` of the release Dockerfile, `push: false`. It compiles the backend and
the frontend from a clean context exactly as a release does, which is what catches both classes
of failure above. Single-arch: neither blocker was architecture-specific, and multi-arch stays on
the release publish where it already is.

Concurrency is set so a new push supersedes the run already going for that branch.

## Testing

The workflow's own first run is on this pull request — that is the test, and it is the honest
one. If the two jobs go green here, CI works; if they do not, it needs fixing before merge either
way.

Validated the YAML parses locally. Beyond that I have deliberately not claimed it works: I cannot
run GitHub Actions from here, and Docker Desktop is down on this machine, so I could not even
rehearse the image job locally.

Both jobs are expected to pass — `main` currently builds clean with 93 tests passing, and I built
this same Dockerfile successfully earlier today before the daemon stopped.

## Impact

CI only; nothing shipped changes. Adds roughly a few minutes to each pull request, most of it the
image build, cached through `type=gha` after the first run.

Worth considering separately: making these checks **required** in the branch protection rule.
Right now they will report but nothing enforces them, and every merge today has gone in with
`--admin`, which bypasses required checks as well as reviews.

## Issue related to PR
- Resolves #237

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.