### PR TITLE
Say fast or slow on every download option

### DIFF
--- a/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.html
+++ b/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.html
@@ -48,17 +48,12 @@
     <ng-template #videoMenu>
       <div class="dropdown-menu" cdkMenu animate.enter="menu-enter" animate.leave="menu-leave">
         @for (rendition of videoRenditions(); track rendition.key + (rendition.convertTo ?? '')) {
-          <!-- A muxed rendition is quality the source only offers as separate video and audio.
-               Its size is a prediction rather than a length the server can declare, and it
-               arrives slower, so it is marked whether or not a size came with it. -->
           <button type="button" class="menu-item" cdkMenuItem
             (cdkMenuItemTriggered)="onDownloadRendition(rendition)">
             <span class="menu-item-label">
               {{ rendition.label }}
               <span class="menu-item-type">{{ typeOf(rendition) }}</span>
-              @if (isMuxed(rendition)) {
-                <span class="menu-item-note">slower</span>
-              }
+              <span class="menu-item-note" [class.menu-item-note--slow]="speedOf(rendition) === 'slow'">{{ speedOf(rendition) }}</span>
             </span>
             @if (sizeOf(rendition)) {
               <span class="menu-item-size">{{ sizeOf(rendition) }}</span>
@@ -73,14 +68,13 @@
     <ng-template #audioMenu>
       <div class="dropdown-menu" cdkMenu animate.enter="menu-enter" animate.leave="menu-leave">
         @for (rendition of audioRenditions(); track rendition.key + (rendition.convertTo ?? '')) {
-          <!-- Converted options come from the server in the same list, marked as such, so
-               they need no case of their own here. -->
           <button type="button" class="menu-item" cdkMenuItem
             [class.menu-item--converted]="!!rendition.convertTo"
             (cdkMenuItemTriggered)="onDownloadRendition(rendition)">
             <span class="menu-item-label">
               {{ rendition.label }}
               <span class="menu-item-type">{{ typeOf(rendition) }}</span>
+              <span class="menu-item-note" [class.menu-item-note--slow]="speedOf(rendition) === 'slow'">{{ speedOf(rendition) }}</span>
             </span>
             @if (rendition.convertTo) {
               <span class="menu-item-size">converted</span>

--- a/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.scss
+++ b/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.scss
@@ -214,7 +214,13 @@
   margin-left: 0.4rem;
   font-size: 0.7rem;
   letter-spacing: 0.02em;
-  opacity: 0.65;
+  opacity: 0.5;
+}
+
+/* The one worth noticing: it is the row that makes you wait. */
+.menu-item-note--slow {
+  color: var(--warning);
+  opacity: 0.9;
 }
 
 /* Not a button: there is nothing to press when a source offers no renditions, and a menu

--- a/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.ts
+++ b/src/ArgonFetch.Frontend/src/app/content-results/single-song-container/single-song-container.component.ts
@@ -52,12 +52,15 @@ export class SingleSongContainerComponent {
   }
 
   /**
-   * Whether a rendition has to be muxed on the way out. Those are the higher resolutions a
-   * source only offers as separate video and audio: worth having, but slower to arrive and
-   * with no size to show beforehand, so the menu says as much before someone picks one.
+   * Whether the server can send this untouched or has to build it first.
+   * <p>
+   * Shown on every rendition rather than only the slow ones: "slower" on its own invites the
+   * question "slower than what", and the answer is only useful next to the alternative.
    */
-  isMuxed(rendition: MediaRenditionDto): boolean {
-    return rendition.urlType === UrlType.Combined;
+  speedOf(rendition: MediaRenditionDto): 'fast' | 'slow' {
+    // Muxed video and converted audio both go through FFmpeg on the way out, which is the
+    // whole of the difference: no declared length, no ranges, and a wait before the first byte.
+    return rendition.urlType === UrlType.Combined || rendition.convertTo ? 'slow' : 'fast';
   }
 
   /** Size label for a rendition, e.g. "3.3 MB". Empty when the source does not report one. */


### PR DESCRIPTION
\slower\ answered a question nobody could ask - slower than what, when the only other rows said nothing at all. Every rendition now carries a badge, so the word means something next to its alternative.

**Audio says it too.** A converted MP3 goes through FFmpeg exactly as a muxed video does, and it was the one row with no hint that it would take longer.

| | |
|---|---|
| \ast\ | sent untouched - declares a length, supports ranges |
| \slow\ | muxed or re-encoded on the way out - no length, no ranges, a wait before the first byte |

Slow is the only one worth noticing, so it is the only one coloured.