### PR TITLE
Delete the hand-rolled .env parser, and read CORS like every other setting

### DIFF
--- a/src/ArgonFetch.API/ArgonFetch.API.csproj
+++ b/src/ArgonFetch.API/ArgonFetch.API.csproj
@@ -11,14 +11,14 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageReference Include="Mediator.SourceGenerator" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.10" />
+	<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.17.2" />
   </ItemGroup>

--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -11,22 +11,6 @@ using YoutubeDLSharp;
 
 var builder = WebApplication.CreateBuilder(args);
 
-if (File.Exists(".env"))
-{
-    foreach (var line in File.ReadAllLines(".env"))
-    {
-        var trimmedLine = line.Trim();
-        if (string.IsNullOrEmpty(trimmedLine) || trimmedLine.StartsWith("#"))
-            continue;
-
-        var parts = trimmedLine.Split('=', 2);
-        if (parts.Length == 2)
-        {
-            Environment.SetEnvironmentVariable(parts[0], parts[1]);
-        }
-    }
-}
-
 #region Configure Services
 builder.Services.AddControllers()
     .AddJsonOptions(o =>
@@ -140,8 +124,10 @@ builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBeh
 #region CORS Configuration
 const string defaultCorsOrigin = "http://localhost:4200";
 
-var allowedOrigins = Environment.GetEnvironmentVariable("CORS_ALLOWED_ORIGINS")?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-    ?? new[] { defaultCorsOrigin }; // Default for development
+// Read like every other setting. Reaching for the environment directly meant this alone
+// answered to a .env file while TOOLS_PATH, COOKIES_PATH and the rest did not.
+var allowedOrigins = builder.Configuration["CORS_ALLOWED_ORIGINS"]?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+    ?? new[] { defaultCorsOrigin };
 
 var corsUsesDevelopmentDefault = allowedOrigins.Length == 1 && allowedOrigins[0] == defaultCorsOrigin;
 

--- a/src/ArgonFetch.Infrastructure/ArgonFetch.Infrastructure.csproj
+++ b/src/ArgonFetch.Infrastructure/ArgonFetch.Infrastructure.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
   </ItemGroup>
 

--- a/src/ArgonFetch.Tests/ArgonFetch.Tests.csproj
+++ b/src/ArgonFetch.Tests/ArgonFetch.Tests.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Closes #240.

Docker Compose already reads \.env\ via \nv_file\ and injects it, and the file was never copied into the image, so in a container this code could not run at all.

Where it did run it barely worked. It executed **after** \CreateBuilder\, by which point the environment had already been read into configuration — so nothing it set reached \uilder.Configuration\, which is how \TOOLS_PATH\, \COOKIES_PATH\, \PROXY_LIST_PATH\ and the whole \Plugins\ section are read.

\CORS_ALLOWED_ORIGINS\ was the one setting that appeared to work, because it alone reached for the environment directly rather than through configuration. That inconsistency is what made the parser look useful, so it now reads like everything else.

For local runs .NET already offers \ppsettings.Development.json\, user secrets and \launchSettings.json\ — all of which reach configuration, which this did not.

## Testing

93 tests pass. Verified against a running app that CORS still works from the environment: an allowed origin gets \Access-Control-Allow-Origin\, an unknown one gets nothing.

## Also

Patch and tooling bumps: \SpaServices.Extensions\ and \Extensions.Http\ to 10.0.11, \FluentValidation.AspNetCore\ to 11.3.1, \coverlet.collector\ to 10.0.1. FluentValidation 12 is a major with breaking changes and is left for its own change.