### PR TITLE
Test the download path, and finish renaming Swagger to Scalar

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ streams and serves them back as a normal file download.
 - **No API keys.** Nothing to register, no credentials to configure — including Spotify.
 - **Plugins.** Sources yt-dlp cannot reach are installed by name rather than built in, and anyone can publish one.
 - **Audio or video**, at a quality you choose.
-- **Web interface and REST API**, with Swagger docs.
+- **Web interface and REST API**, with a browsable API reference.
 - **One container, no database.** Runs anywhere Docker does.
 
 ## Screenshots
@@ -169,7 +169,7 @@ migrating — ArgonFetch keeps no persistent state at all.
 2. Paste a media URL and press Enter
 3. Pick a quality, then download
 
-API docs are at `http://localhost:8080/swagger` when running in `Development`.
+API docs are at `http://localhost:8080/scalar` when running in `Development`.
 
 The schema is also checked in at [`docs/public/openapi.json`](docs/public/openapi.json) for generating
 clients elsewhere without running the app. Refresh it from a running instance after changing

--- a/docs/api.md
+++ b/docs/api.md
@@ -98,7 +98,7 @@ seconds of a start.
 
 These pages are generated from [`openapi.json`](/openapi.json), which is checked in at
 `docs/public/openapi.json` so clients can be generated without running the app. The reference UI is also
-served at `/swagger` when `ASPNETCORE_ENVIRONMENT=Development`.
+served at `/scalar` when `ASPNETCORE_ENVIRONMENT=Development`.
 
 Refresh the schema from a running instance after changing any endpoint or DTO - the pages here
 follow automatically:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Everything is set through environment variables, normally in the `.env` file nex
 | Variable | Required | Description |
 |---|---|---|
 | `CORS_ALLOWED_ORIGINS` | in production | Comma-separated origins allowed to call the API. Defaults to `http://localhost:4200`, and the app warns at startup if that default is still in use in production |
-| `ASPNETCORE_ENVIRONMENT` | no | Already `Production` when unset - set it only to run as `Development`, which enables the Swagger UI |
+| `ASPNETCORE_ENVIRONMENT` | no | Already `Production` when unset - set it only to run as `Development`, which enables the API reference at `/scalar` |
 | `TOOLS_PATH` | no | Where `yt-dlp` and `FFmpeg` are downloaded to. `/tools` in the image, which is the path the compose file mounts a volume on. Must be writable by the runtime user |
 | `PROXY_LIST_PATH` | no | File with one proxy per line, rotated across `yt-dlp` fetches so they do not all leave from the same IP. See [below](#proxy-rotation) |
 | `COOKIES_PATH` | no | Netscape-format cookies file exported from a signed-in browser, for sources that serve nothing to strangers. See [Platforms](/platforms#sites-that-need-an-account) |

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -23,7 +23,7 @@ cd ArgonFetch
 ## 2. Run both halves
 
 ```bash
-# API - http://localhost:5114, Swagger at /swagger
+# API - http://localhost:5114, API reference at /scalar
 cd src/ArgonFetch.API
 dotnet run
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ features:
   - title: Audio or video, your quality
     details: Every rendition the source offers is listed. Audio passes through in its original container; MP3 on request.
   - title: Web UI and REST API
-    details: One interface for people, one JSON API for scripts, with a Swagger page and a checked-in OpenAPI schema.
+    details: One interface for people, one JSON API for scripts, with an API reference and a checked-in OpenAPI schema.
   - title: One container plus a database
     details: yt-dlp and FFmpeg are fetched at boot and update themselves, so extractor fixes land without rebuilding anything.
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,7 +94,7 @@ responses are pipes.
 ## Trying the API without curl
 
 Every endpoint has a page under [API](/api) with a playground that sends the request for you,
-against the hosted instance or your own. The reference UI is also served at `/swagger`, though only when
+against the hosted instance or your own. The reference UI is also served at `/scalar`, though only when
 the instance runs with `ASPNETCORE_ENVIRONMENT=Development` - so on a local build, not on
 app.argonfetch.dev. The schema is checked in at [`openapi.json`](/openapi.json) either way, for
 generating clients without running anything.

--- a/src/ArgonFetch.API/Properties/launchSettings.json
+++ b/src/ArgonFetch.API/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
@@ -13,7 +13,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar",
       "applicationUrl": "http://localhost:5114",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -23,7 +23,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar",
       "applicationUrl": "https://localhost:7290;http://localhost:5114",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -32,7 +32,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchUrl": "scalar",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/ArgonFetch.Tests/AcceleratedDownloadServiceTests.cs
+++ b/src/ArgonFetch.Tests/AcceleratedDownloadServiceTests.cs
@@ -1,0 +1,184 @@
+using System.Net;
+using System.Net.Http.Headers;
+using ArgonFetch.Application.Services;
+using ArgonFetch.Infrastructure.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace ArgonFetch.Tests
+{
+    public class AcceleratedDownloadServiceTests
+    {
+        // Larger than the 2 MB minimum chunk, so a download of it is split and reassembled
+        // rather than arriving in one piece.
+        private const int FileSize = 5 * 1024 * 1024;
+
+        [Fact]
+        public async Task StreamWithAcceleration_ReassemblesTheFileInOrder()
+        {
+            var source = Bytes(FileSize);
+            var output = new MemoryStream();
+
+            await Service(source).StreamWithAccelerationAsync("https://example.test/file", output);
+
+            Assert.Equal(source, output.ToArray());
+        }
+
+        [Fact]
+        public async Task StreamWithAcceleration_WritesOnlyTheRequestedWindow()
+        {
+            // What a client seeking into a file asks for. Writing anything else makes the body
+            // disagree with the Content-Range already announced.
+            var source = Bytes(FileSize);
+            var output = new MemoryStream();
+            var window = new ByteRange(1_000_000, 3_500_000);
+
+            await Service(source).StreamWithAccelerationAsync("https://example.test/file", output, range: window);
+
+            Assert.Equal(source[(int)window.From..((int)window.To + 1)], output.ToArray());
+        }
+
+        [Fact]
+        public async Task StreamWithAcceleration_AsksForOffsetsIntoTheFileNotIntoTheWindow()
+        {
+            // A window near the end must fetch the end of the resource. Asking from zero would
+            // return the right number of bytes from entirely the wrong place.
+            var source = Bytes(FileSize);
+            var output = new MemoryStream();
+            var window = new ByteRange(FileSize - 3_000_000, FileSize - 1);
+
+            var handler = new RangeServer(source);
+            await Service(source, handler).StreamWithAccelerationAsync("https://example.test/file", output, range: window);
+
+            Assert.Equal(source[(int)window.From..], output.ToArray());
+            Assert.All(handler.RangesRequested.Skip(1), r => Assert.True(r.From >= window.From));
+        }
+
+        [Fact]
+        public async Task StreamWithAcceleration_FallsBackToOneConnectionWhenRangesAreRefused()
+        {
+            var source = Bytes(FileSize);
+            var output = new MemoryStream();
+
+            await Service(source, new RangeServer(source) { AcceptsRanges = false })
+                .StreamWithAccelerationAsync("https://example.test/file", output);
+
+            Assert.Equal(source, output.ToArray());
+        }
+
+        [Fact]
+        public async Task StreamWithAcceleration_FallsBackWhenTheProbeFails()
+        {
+            var source = Bytes(FileSize);
+            var output = new MemoryStream();
+
+            await Service(source, new RangeServer(source) { FailProbe = true })
+                .StreamWithAccelerationAsync("https://example.test/file", output);
+
+            Assert.Equal(source, output.ToArray());
+        }
+
+        [Fact]
+        public async Task StreamWithAcceleration_DoesNotRetryOnceBytesHaveBeenWritten()
+        {
+            // Retrying here would append a second copy to a response that already holds part of
+            // one, which is worse than the failure it is trying to hide.
+            var source = Bytes(FileSize);
+            var output = new MemoryStream();
+            var handler = new RangeServer(source) { FailAfterChunks = 1 };
+
+            await Assert.ThrowsAnyAsync<Exception>(() =>
+                Service(source, handler).StreamWithAccelerationAsync("https://example.test/file", output));
+
+            Assert.True(output.Length > 0, "the first chunk should have reached the output");
+            Assert.True(output.Length < source.Length, "the download should not have completed");
+        }
+
+        [Fact]
+        public async Task GetContentLength_ReportsWhatTheSourceDeclares()
+        {
+            var source = Bytes(FileSize);
+
+            Assert.Equal(FileSize, await Service(source).GetContentLengthAsync("https://example.test/file"));
+        }
+
+        [Fact]
+        public async Task GetContentLength_IsNullWhenTheSourceCannotBeReached()
+        {
+            // An answer rather than a fault: the caller declares no length and sends chunked.
+            var service = Service(Bytes(1024), new RangeServer(Bytes(1024)) { FailProbe = true });
+
+            Assert.Null(await service.GetContentLengthAsync("https://example.test/file"));
+        }
+
+        private static AcceleratedDownloadService Service(byte[] source, RangeServer? handler = null) =>
+            new(new StubClients(handler ?? new RangeServer(source)),
+                NullLogger<AcceleratedDownloadService>.Instance);
+
+        /// <summary>Deterministic content, so a misplaced chunk shows up as a difference.</summary>
+        private static byte[] Bytes(int count)
+        {
+            var bytes = new byte[count];
+
+            for (var i = 0; i < count; i++)
+                bytes[i] = (byte)(i % 251);
+
+            return bytes;
+        }
+
+        private sealed class StubClients(HttpMessageHandler handler) : IMediaHttpClients
+        {
+            private readonly HttpClient _client = new(handler);
+
+            public HttpClient For(string? proxy) => _client;
+        }
+
+        /// <summary>A source that serves byte ranges, and can be made to misbehave.</summary>
+        private sealed class RangeServer(byte[] content) : HttpMessageHandler
+        {
+            private int _chunksServed;
+
+            public bool AcceptsRanges { get; init; } = true;
+            public bool FailProbe { get; init; }
+            public int? FailAfterChunks { get; init; }
+
+            public List<ByteRange> RangesRequested { get; } = [];
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var range = request.Headers.Range?.Ranges.FirstOrDefault();
+                var isProbe = range?.From == 0 && range?.To == 0;
+
+                if (isProbe && FailProbe)
+                    throw new HttpRequestException("probe refused");
+
+                if (!AcceptsRanges)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ByteArrayContent(content)
+                    });
+                }
+
+                if (!isProbe && FailAfterChunks is { } limit && Interlocked.Increment(ref _chunksServed) > limit)
+                    throw new HttpRequestException("source gave up");
+
+                var from = range?.From ?? 0;
+                var to = range?.To ?? content.Length - 1;
+
+                if (!isProbe)
+                    RangesRequested.Add(new ByteRange(from, to));
+
+                var slice = content[(int)from..(int)(to + 1)];
+
+                var response = new HttpResponseMessage(HttpStatusCode.PartialContent)
+                {
+                    Content = new ByteArrayContent(slice)
+                };
+
+                response.Content.Headers.ContentRange = new ContentRangeHeaderValue(from, to, content.Length);
+
+                return Task.FromResult(response);
+            }
+        }
+    }
+}

--- a/src/ArgonFetch.Tests/ArgonFetch.Tests.csproj
+++ b/src/ArgonFetch.Tests/ArgonFetch.Tests.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ArgonFetch.Abstractions\ArgonFetch.Abstractions.csproj" />
     <ProjectReference Include="..\ArgonFetch.Application\ArgonFetch.Application.csproj" />
+    <ProjectReference Include="..\ArgonFetch.Infrastructure\ArgonFetch.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Every test so far covered a small pure helper — naming, ranges, pickers, pools. The code that moves the bytes had none, and that is where a mistake does not throw: it hands somebody a corrupt file.

Eight tests for the accelerated downloader, each one a way that could happen:

- the file comes back **byte for byte**, reassembled in request order
- a **windowed download writes exactly the requested bytes** — anything else makes the body disagree with the `Content-Range` already announced
- a **window near the end asks for the end of the resource**, rather than fetching the right number of bytes from the wrong place
- a source that **refuses ranges**, and a **probe that fails outright**, both fall back to one connection and still deliver the whole file
- a **failure after bytes are written is not retried**, because a retry appends a second copy to a response already holding part of one

That last one is the reason the `when (output.BytesWritten == 0)` guard exists, and nothing was checking it.

The tests use a fake range server rather than the network, so they run in the CI added by #238 — which previously could not have caught a regression here at all.

## Also: the Swagger rename was not finished

#241 moved the endpoint but left seven references pointing at `/swagger`, including `launchSettings.json`, which opened it on every F5 — a 404 since the move. The [official docs](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/using-openapi-documents) specifically say to set `launchUrl` to `scalar`.

The checked-in `openapi.json` needed no update: the build regenerates it, and it was already byte-identical. That is what build-time generation was for.

101 tests pass.
