### PR TITLE
Speak MCP at /mcp, so an AI assistant can use ArgonFetch without glue code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ streams and serves them back as a normal file download.
 - **Plugins.** Sources yt-dlp cannot reach are installed by name rather than built in, and anyone can publish one.
 - **Audio or video**, at a quality you choose.
 - **Web interface and REST API**, with a browsable API reference.
+- **MCP endpoint** at `/mcp`, so an AI assistant can resolve a link and download it directly.
 - **One container, no database.** Runs anywhere Docker does.
 
 ## Screenshots
@@ -170,6 +171,14 @@ migrating — ArgonFetch keeps no persistent state at all.
 3. Pick a quality, then download
 
 API docs are at `http://localhost:8080/scalar` when running in `Development`.
+
+To use ArgonFetch from an AI assistant, point an MCP client at `http://localhost:8080/mcp`:
+
+```bash
+claude mcp add --transport http argonfetch http://localhost:8080/mcp
+```
+
+See the [MCP guide](https://docs.argonfetch.dev/mcp) (source: [`docs/mcp.md`](docs/mcp.md)).
 
 The schema is also checked in at [`docs/public/openapi.json`](docs/public/openapi.json) for generating
 clients elsewhere without running the app. Refresh it from a running instance after changing

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
       { text: 'Setup', link: '/self-host' },
       { text: 'Usage', link: '/usage' },
       { text: 'API', link: '/api' },
+      { text: 'MCP', link: '/mcp' },
       { text: 'Development', link: '/dev-setup' },
       { text: 'Live app', link: 'https://app.argonfetch.dev' },
     ],
@@ -62,6 +63,7 @@ export default defineConfig({
         items: [
           { text: 'Usage', link: '/usage' },
           { text: 'Supported platforms', link: '/platforms' },
+          { text: 'MCP for AI assistants', link: '/mcp' },
         ],
       },
       {

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,9 @@ point it at your own instance instead - and make sure that instance lists `docs.
 `Fetch` and `Stream` are the pair you want: resolve a URL, then stream the `key` you picked out of
 the response. [Usage](/usage#from-the-command-line) walks through both with `curl`.
 
+An AI assistant should use [MCP](/mcp) at `POST /mcp` instead. It is the same resolution, with the
+key already turned into a URL that can be fetched as it stands.
+
 ## Filenames
 
 Both stream endpoints send a `Content-Disposition` built from the media, so a client that respects

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,6 +14,8 @@ and nothing to configure - not even Spotify credentials.
   so you can see what you are choosing.
 - **Web interface and REST API.** The UI is one input box; the API is a handful of `GET`
   endpoints, documented at `/scalar` and checked in as [`openapi.json`](/openapi.json).
+- **Usable by an AI assistant.** ArgonFetch speaks [MCP](/mcp) at `/mcp`, so an assistant resolves
+  a link and gets a URL it can fetch - no glue code, no API keys.
 - **One container, no database.** Resolved media is cached in memory. Everything else
   runs in the app container.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,124 @@
+# MCP
+
+ArgonFetch speaks [Model Context Protocol](https://modelcontextprotocol.io) at `/mcp`, so an AI
+assistant can resolve a link and download the file without a person translating the REST API for
+it.
+
+There is no authentication, exactly as with the REST API. Anyone who can reach `/mcp` can use it,
+so an instance on the open internet is an instance anyone can download through - the same caveat
+as [Self-hosting](/self-host).
+
+## Connecting
+
+The endpoint is [streamable HTTP](https://modelcontextprotocol.io/specification/basic/transports),
+which every current MCP client supports. Point yours at:
+
+```
+https://app.argonfetch.dev/mcp
+```
+
+Swap the host for your own instance - `http://localhost:8080/mcp` by default.
+
+**Claude Code:**
+
+```bash
+claude mcp add --transport http argonfetch https://app.argonfetch.dev/mcp
+```
+
+**Claude Desktop, and anything else reading a JSON config:**
+
+```json
+{
+  "mcpServers": {
+    "argonfetch": {
+      "type": "http",
+      "url": "https://app.argonfetch.dev/mcp"
+    }
+  }
+}
+```
+
+The server is stateless - it never calls back to the client - so nothing has to be pinned to one
+replica and there is no session to keep alive.
+
+## The tool
+
+One tool, `fetch_media`, taking the page URL:
+
+| Argument | |
+|---|---|
+| `url` | The page to resolve, for example `https://www.youtube.com/watch?v=dQw4w9WgXcQ` |
+
+It answers with the title, author, cover and the renditions, split into `video` and `audio`. Each
+rendition carries a `downloadUrl` that is a plain `GET` and needs nothing added to it:
+
+```json
+{
+  "type": "Media",
+  "items": [
+    {
+      "title": "Rick Astley - Never Gonna Give You Up (Official Video) (4K Remaster)",
+      "author": "Rick Astley",
+      "sourceUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "video": [
+        {
+          "label": "1080p",
+          "fileExtension": ".mp4",
+          "fileSizeBytes": 84345754,
+          "downloadUrl": "https://app.argonfetch.dev/api/Stream/Combined/0UStZ80UE8E7onWo"
+        }
+      ],
+      "audio": [
+        {
+          "label": "192 kbps",
+          "description": "Converted from 129 kbps",
+          "fileExtension": ".mp3",
+          "downloadUrl": "https://app.argonfetch.dev/api/Stream/Media/ZMWVLizyW7957Knd?format=mp3"
+        }
+      ]
+    }
+  ]
+}
+```
+
+This is the difference from calling the REST API directly. There, a rendition carries a `key`, and
+the caller has to know that `urlType` decides between two endpoints and that a converted rendition
+needs `?format=mp3`. The tool resolves all of that, so the model has a URL rather than a puzzle -
+see [API](/api) for the endpoints underneath.
+
+The URLs stop working an hour after the call that produced them, which the server tells the model
+up front.
+
+### Playlists
+
+A playlist answers with `type: "PlayList"` and one entry per track, each with a title and a
+`sourceUrl` but no renditions - resolving two hundred tracks up front would take minutes. Calling
+`fetch_media` again with a track's `sourceUrl` gets that track's download URLs.
+
+## Instructions the server sends
+
+At `initialize`, ArgonFetch sends a set of instructions describing when to use the tool, how to
+pick a rendition when the user did not say, and that a `downloadUrl` is to be fetched or handed
+over rather than pulled through the tool result. Clients that show a server's instructions - or
+that pass them to the model, which is most of them - need nothing configured on top.
+
+They live in `Program.cs`, next to `AddMcpServer`, so an instance that changes them changes what
+every connected assistant is told.
+
+## Browser-based clients
+
+A client running in a browser needs the instance to allow its origin, the same as any other
+cross-origin caller - see [Configuration](/configuration#cors). Clients that run outside the
+browser, which includes Claude Desktop and Claude Code, are unaffected.
+
+## Errors
+
+A failure reaches the model as a tool error carrying the reason, so it can tell the user something
+useful rather than retrying blindly:
+
+| What happened | What the model is told |
+|---|---|
+| The link resolved to nothing | `Nothing was found at <url>.` |
+| DRM, or a link shape ArgonFetch does not handle | The reason, as `GetResource` reports it |
+| The instance is updating `yt-dlp` and `FFmpeg` | The current activity, and that the call will work shortly |
+| Anything else | `Could not fetch <url>.`, with the detail in the server log |

--- a/src/ArgonFetch.API/ArgonFetch.API.csproj
+++ b/src/ArgonFetch.API/ArgonFetch.API.csproj
@@ -20,6 +20,7 @@
     </PackageReference>
 	<PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="10.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.17.2" />
   </ItemGroup>
 

--- a/src/ArgonFetch.API/Mcp/ArgonFetchTools.cs
+++ b/src/ArgonFetch.API/Mcp/ArgonFetchTools.cs
@@ -1,0 +1,97 @@
+using System.ComponentModel;
+using ArgonFetch.Application.Dtos;
+using ArgonFetch.Application.Queries;
+using ArgonFetch.Application.Services;
+using Mediator;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+
+namespace ArgonFetch.API.Mcp
+{
+    /// <summary>
+    /// The MCP face of the API. It sends the same query <see cref="Controllers.FetchController"/>
+    /// does, so there is one resolution path, and resolves the rendition key into a URL the caller
+    /// can simply GET - which the REST response leaves to the caller.
+    /// </summary>
+    [McpServerToolType]
+    public class ArgonFetchTools(
+        IMediator mediator,
+        IHttpContextAccessor httpContextAccessor,
+        IMaintenanceState maintenance,
+        ILogger<ArgonFetchTools> logger)
+    {
+        [McpServerTool(Name = "fetch_media", ReadOnly = true, OpenWorld = true)]
+        [Description("""
+            Resolve a media link (YouTube, TikTok, Spotify, SoundCloud, Instagram and anything else
+            yt-dlp handles) into its title, author and download URLs.
+
+            Every rendition carries a downloadUrl that can be fetched directly - no second call, no
+            parameters to add. Those URLs stop working an hour after this call, so resolve again
+            rather than reusing an old result.
+
+            A playlist answers with one entry per track in `items`, each with a title and a
+            `sourceUrl` but no renditions - call this again with that `sourceUrl` to get the
+            download URLs for a track.
+            """)]
+        public async Task<object> FetchMediaAsync(
+            [Description("The page URL to resolve, for example https://www.youtube.com/watch?v=dQw4w9WgXcQ")]
+            string url,
+            CancellationToken cancellationToken)
+        {
+            if (maintenance.Activity is { } activity)
+                throw new McpException($"{activity}. The server is briefly unavailable while it updates itself; try again in a moment.");
+
+            ResourceInformationDto resource;
+
+            try
+            {
+                resource = await mediator.Send(new GetMediaQuery(url), cancellationToken);
+            }
+            catch (ArgumentException)
+            {
+                throw new McpException($"Nothing was found at {url}.");
+            }
+            catch (NotSupportedException ex)
+            {
+                // DRM, or a link shape ArgonFetch does not handle. The reason is the useful part.
+                throw new McpException(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "MCP fetch failed for {Url}", url);
+
+                throw new McpException($"Could not fetch {url}.");
+            }
+
+            var request = httpContextAccessor.HttpContext!.Request;
+            var origin = $"{request.Scheme}://{request.Host}";
+
+            return new
+            {
+                Type = resource.Type.ToString(),
+                resource.Title,
+                resource.Author,
+                resource.CoverUrl,
+                Items = resource.MediaItems.Select(item => new
+                {
+                    item.Title,
+                    item.Author,
+                    SourceUrl = item.RequestedUrl,
+                    item.CoverUrl,
+                    Video = Downloads(origin, item.Video),
+                    Audio = Downloads(origin, item.Audio)
+                })
+            };
+        }
+
+        private static object[] Downloads(string origin, StreamReferenceDto? reference) =>
+            reference?.Renditions.Select(object (rendition) => new
+            {
+                rendition.Label,
+                rendition.Description,
+                rendition.FileExtension,
+                rendition.FileSizeBytes,
+                DownloadUrl = DownloadUrlBuilder.UrlFor(origin, rendition)
+            }).ToArray() ?? [];
+    }
+}

--- a/src/ArgonFetch.API/Program.cs
+++ b/src/ArgonFetch.API/Program.cs
@@ -5,6 +5,7 @@ using FluentValidation;
 using FluentValidation.AspNetCore;
 using Mediator;
 using Microsoft.OpenApi;
+using ModelContextProtocol.AspNetCore;
 using Scalar.AspNetCore;
 using System.Text.Json.Serialization;
 using YoutubeDLSharp;
@@ -36,6 +37,46 @@ builder.Services.AddHostedService(
     sp => sp.GetRequiredService<ArgonFetch.Infrastructure.Services.MediaToolsService>());
 
 builder.Services.AddSingleton<ArgonFetch.Application.Services.IApplicationInfoService, ArgonFetch.Infrastructure.Services.ApplicationInfoService>();
+#endregion
+
+#region MCP
+// The same GetMediaQuery the REST controller sends, exposed as a tool so an assistant can use
+// ArgonFetch without being taught how a rendition key becomes a download URL. Stateless: nothing
+// here calls back to the client, so no session has to be pinned to one replica.
+builder.Services.AddMcpServer(options => options.ServerInstructions = """
+        ArgonFetch turns a media link into a downloadable file. It handles YouTube, TikTok,
+        Spotify, SoundCloud, Instagram and everything else yt-dlp reaches, including playlists.
+
+        Call `fetch_media` with the page URL the user gave you. It answers with the title, author
+        and a list of renditions - `video` and `audio` - each carrying a `downloadUrl`.
+
+        A playlist answers with `type: "PlayList"` and one entry per track, and those entries carry
+        titles but no renditions - resolving two hundred tracks up front would take minutes. Call
+        `fetch_media` again with a track's `sourceUrl` to get its download URLs, and do that only
+        for the tracks the user actually wants.
+
+        A `downloadUrl` is a plain GET and needs nothing added to it. Fetch it directly, or hand it
+        to the user. Do not ask ArgonFetch for the bytes: it streams files that run to hundreds of
+        megabytes, so the URL is the deliverable, not the content.
+
+        Picking a rendition, when the user did not say:
+
+        - audio only, or a song -> the highest `label` bitrate under `audio`
+        - video -> the highest `label` resolution under `video` whose `fileSizeBytes` is sane for
+          what the user is doing; 1080p is a good default, 2160p is often over 200 MB
+        - the `.mp3` rendition is transcoded on the fly and is the only audio option that carries
+          title and artist tags inside the file - prefer it when the user is building a library,
+          and prefer the source container otherwise, because it is faster and lossless
+
+        A `downloadUrl` stops working one hour after the call that produced it. Call `fetch_media`
+        again rather than reusing a URL from earlier in the conversation.
+
+        Errors say what went wrong and are worth relaying: DRM-protected media cannot be
+        downloaded no matter how the request is phrased, and a message about updating means the
+        instance is briefly busy and the same call will work shortly.
+        """)
+    .WithHttpTransport(options => options.SessionMode = HttpServerSessionMode.Stateless)
+    .WithTools<ArgonFetch.API.Mcp.ArgonFetchTools>();
 #endregion
 
 #region API Documentation
@@ -204,6 +245,9 @@ app.UseRouting();
 app.UseAuthorization();
 app.UseCors();
 app.MapControllers();
+
+// Outside /api, so neither the fallback below nor the SPA competes for it.
+app.MapMcp("/mcp");
 
 app.MapFallback("/api/{**path}", (HttpContext context) => Results.Problem(
     title: "Not Found",

--- a/src/ArgonFetch.Application/Services/DownloadUrlBuilder.cs
+++ b/src/ArgonFetch.Application/Services/DownloadUrlBuilder.cs
@@ -1,0 +1,21 @@
+using ArgonFetch.Application.Dtos;
+using ArgonFetch.Application.Enums;
+
+namespace ArgonFetch.Application.Services
+{
+    /// <summary>
+    /// Turns a rendition into the path that streams it. The REST response hands out a key and
+    /// leaves this to the caller; a tool call has no human to read the docs, so it resolves here.
+    /// </summary>
+    public static class DownloadUrlBuilder
+    {
+        public static string PathFor(MediaRenditionDto rendition) =>
+            rendition.UrlType == UrlType.Combined
+                ? $"/api/Stream/Combined/{rendition.Key}"
+                : $"/api/Stream/Media/{rendition.Key}"
+                  + (rendition.ConvertTo is null ? string.Empty : $"?format={rendition.ConvertTo}");
+
+        public static string UrlFor(string origin, MediaRenditionDto rendition) =>
+            origin.TrimEnd('/') + PathFor(rendition);
+    }
+}

--- a/src/ArgonFetch.Tests/DownloadUrlBuilderTests.cs
+++ b/src/ArgonFetch.Tests/DownloadUrlBuilderTests.cs
@@ -1,0 +1,47 @@
+using ArgonFetch.Application.Dtos;
+using ArgonFetch.Application.Enums;
+using ArgonFetch.Application.Services;
+
+namespace ArgonFetch.Tests
+{
+    public class DownloadUrlBuilderTests
+    {
+        private static MediaRenditionDto Rendition(UrlType urlType, string? convertTo = null) =>
+            new()
+            {
+                Key = "abc123",
+                Label = "1080p",
+                FileExtension = ".mp4",
+                MimeType = "video/mp4",
+                UrlType = urlType,
+                ConvertTo = convertTo
+            };
+
+        [Fact]
+        public void PathFor_SendsCombinedRenditionsToTheMuxingEndpoint()
+        {
+            Assert.Equal("/api/Stream/Combined/abc123", DownloadUrlBuilder.PathFor(Rendition(UrlType.Combined)));
+        }
+
+        [Fact]
+        public void PathFor_SendsSingleStreamsToTheMediaEndpoint()
+        {
+            Assert.Equal("/api/Stream/Media/abc123", DownloadUrlBuilder.PathFor(Rendition(UrlType.Media)));
+        }
+
+        [Fact]
+        public void PathFor_AsksForTheConversionARenditionDeclares()
+        {
+            // Without this the MP3 rendition streams the source codec under an .mp3 name.
+            Assert.Equal("/api/Stream/Media/abc123?format=mp3",
+                DownloadUrlBuilder.PathFor(Rendition(UrlType.Media, convertTo: "mp3")));
+        }
+
+        [Fact]
+        public void UrlFor_JoinsTheOriginWithoutDoublingTheSlash()
+        {
+            Assert.Equal("https://app.argonfetch.dev/api/Stream/Media/abc123",
+                DownloadUrlBuilder.UrlFor("https://app.argonfetch.dev/", Rendition(UrlType.Media)));
+        }
+    }
+}


### PR DESCRIPTION
Closes #244.

`POST /mcp` speaks [MCP](https://modelcontextprotocol.io) over streamable HTTP, so an assistant can
resolve a link and download the file without a person translating the REST API for it.

## What is here

One tool, `fetch_media`, sending the same `GetMediaQuery` `FetchController` sends - there is no
second resolution path to keep in sync. What it adds is the part the REST response leaves to the
caller: `UrlType` picks between `/api/Stream/Combined/{key}` and `/api/Stream/Media/{key}`, and a
rendition with `ConvertTo` needs `?format=mp3`. `DownloadUrlBuilder` resolves both, so every
rendition comes back with an absolute `downloadUrl` that is a plain GET.

```json
{
  "label": "192 kbps",
  "description": "Converted from 129 kbps",
  "fileExtension": ".mp3",
  "downloadUrl": "http://localhost:5114/api/Stream/Media/ZMWVLizyW7957Knd?format=mp3"
}
```

Stateless - nothing here calls back to the client - so no session is pinned to a replica.
`/mcp` sits outside `/api`, so neither `MapFallback("/api/{**path}")` nor the SPA competes for it.

## Instructions for the model

The server sends [`instructions`](https://modelcontextprotocol.io/specification/basic/lifecycle) at
`initialize`, next to `AddMcpServer` in `Program.cs`, so a client does not have to be told any of
this by hand:

- call `fetch_media` with the page URL, then fetch or hand over the `downloadUrl`
- do not pull the bytes through the tool result - these files run to hundreds of megabytes
- how to pick a rendition when the user did not say, and when the `.mp3` transcode is worth it
  (it is the only audio option carrying tags) versus the source container (faster, lossless)
- a `downloadUrl` expires an hour after the call that produced it

## One thing the end-to-end run turned up

A playlist answers with 200 titles and **no renditions** - resolving them up front would take
minutes, so entries carry `sourceUrl` and nothing else. The REST API has always behaved this way;
it is simply undocumented, and a model would have concluded the playlist had no audio. Both the
server instructions and the tool description now say to resolve a track by its `sourceUrl`.

## No authentication

Deliberate, and it matches the REST API - `/mcp` is exactly as open as `/api`. Both should gain
auth together or not at all.

## Tested end to end

Against a running instance on `localhost:5114`, over real `curl` JSON-RPC:

| | |
|---|---|
| `initialize` | `2025-06-18`, 1833 characters of instructions |
| `tools/list` | `fetch_media`, `url` required, `readOnlyHint` + `openWorldHint` set |
| Single video | Rick Astley, 4 video + 5 audio renditions |
| Combined URL | `GET` -> `200`, 5,461,512 bytes, `video/mp4`, named from `Content-Disposition` |
| `?format=mp3` URL | `GET` -> `200`, 5,113,898 bytes, `audio/mpeg` |
| Playlist | `type: PlayList`, 200 tracks, entries carry `sourceUrl` only |
| Playlist track | resolved by `sourceUrl` -> 5 audio + 4 video, mp3 downloaded, `200`, `audio/mpeg` |
| Bad link | `isError: true`, "Nothing was found at ..." |

`dotnet test`: 105 passed, including 4 new ones covering the two endpoints, the `?format=` branch
and the origin join. `vitepress build` passes.

## Docs

New [`docs/mcp.md`](docs/mcp.md) - connecting, the tool, playlists, the instructions, the CORS
caveat for browser-based clients, and the error table - wired into the nav and sidebar, with
pointers from `README.md`, `docs/intro.md` and `docs/api.md`.

`openapi.json` is unchanged: MCP is not a controller, so nothing in the REST schema moved.
